### PR TITLE
Chore/mount adminjs in root for local dev and admin in prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,6 @@ on:
       - 'infrastructure/**'
       - 'package.json'
 
-
-
 jobs:
 
   set_environment_name:
@@ -252,7 +250,7 @@ jobs:
               restart: always
               ports:
                 - 4000:4000
-            administration:
+            admin:
               image: $ECR_REGISTRY/$ECR_REPOSITORY_ADMIN:$IMAGE_TAG
               restart: always
               ports:
@@ -268,7 +266,7 @@ jobs:
               depends_on:
                 - api
                 - client
-                - administration
+                - admin
           EOF
 
       - name: Generate zip file

--- a/admin/index.ts
+++ b/admin/index.ts
@@ -28,7 +28,7 @@ const start = async () => {
   };
 
   const admin = new AdminJS({
-    rootPath: "/administration",
+    rootPath: "/",
     componentLoader,
     resources: [
       {

--- a/infrastructure/source_bundle/proxy/conf.d/application.conf
+++ b/infrastructure/source_bundle/proxy/conf.d/application.conf
@@ -6,8 +6,8 @@ upstream client {
     server client:3000;
 }
 
-upstream administration {
-    server administration:1000;
+upstream admin {
+    server admin:1000;
 }
 
 server {
@@ -41,8 +41,9 @@ server {
                 proxy_pass_request_headers on;
                 client_max_body_size 200m;
             }
-    location /administration/ {
-                    proxy_pass http://administration;
+    location /admin/ {
+                    rewrite ^/admin/?(.*)$ /$1 break;
+                    proxy_pass http://admin;
                     proxy_http_version 1.1;
                     proxy_set_header X-Forwarded-Host $host;
                     proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
This pull request includes several changes to standardize the naming conventions and simplify the configuration across different files. The most important changes include renaming the `administration` service to `admin` and updating the corresponding paths and references.

### Naming Convention Updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L255-R253): Changed service name from `administration` to `admin` and updated related job dependencies. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L255-R253) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L271-R269)
* [`infrastructure/source_bundle/proxy/conf.d/application.conf`](diffhunk://#diff-bc85ce908f6af6dfd9a41ce6c1c29ce74ae5282d31420df682671b60512c5693L9-R10): Renamed `upstream administration` to `upstream admin` and updated the proxy path from `/administration/` to `/admin/`. [[1]](diffhunk://#diff-bc85ce908f6af6dfd9a41ce6c1c29ce74ae5282d31420df682671b60512c5693L9-R10) [[2]](diffhunk://#diff-bc85ce908f6af6dfd9a41ce6c1c29ce74ae5282d31420df682671b60512c5693L44-R46)

### Path Updates:

* [`admin/index.ts`](diffhunk://#diff-c5dba8b9879cf47d9d5c9d01d5eef7470e70f77ed29a437d60f35888ff43c05fL31-R31): Changed the `rootPath` for `AdminJS` from `/administration` to `/`.

### Miscellaneous:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L18-L19): Removed unnecessary blank lines for cleaner formatting.