### PR TITLE
remove general user role

### DIFF
--- a/client/src/containers/profile/account-details/schema.ts
+++ b/client/src/containers/profile/account-details/schema.ts
@@ -4,6 +4,6 @@ import { z } from "zod";
 
 export const accountDetailsSchema = UpdateUserSchema.and(
   z.object({
-    role: z.enum([ROLES.ADMIN, ROLES.PARTNER, ROLES.GENERAL_USER]).optional(),
+    role: z.enum([ROLES.ADMIN, ROLES.PARTNER]).optional(),
   }),
 );

--- a/shared/entities/users/roles.enum.ts
+++ b/shared/entities/users/roles.enum.ts
@@ -1,5 +1,4 @@
 export enum ROLES {
-  ADMIN = 'admin',
-  PARTNER = 'partner',
-  GENERAL_USER = 'general_user',
+  ADMIN = "admin",
+  PARTNER = "partner",
 }

--- a/shared/entities/users/user.entity.ts
+++ b/shared/entities/users/user.entity.ts
@@ -34,7 +34,7 @@ export class User extends BaseEntity {
 
   @Column({
     type: "enum",
-    default: ROLES.GENERAL_USER,
+    default: ROLES.PARTNER,
     enum: ROLES,
     enumName: "user_roles",
   })


### PR DESCRIPTION
This pull request includes changes to the user role management in the project. The main focus is on removing the `GENERAL_USER` role and updating the default role for users.

Changes to user roles:

* [`client/src/containers/profile/account-details/schema.ts`](diffhunk://#diff-b5815fada5d0499f6927eddd3f1da1f6a57a3893227621f367ede6383d8d1a50L7-R7): Removed the `GENERAL_USER` role from the `role` enumeration in the `accountDetailsSchema`.
* [`shared/entities/users/roles.enum.ts`](diffhunk://#diff-3bf12782ae865ed75c3d57809d95ac89c6f204763a7c65fdf039e69e65af80deL2-R3): Removed the `GENERAL_USER` role from the `ROLES` enum.
* [`shared/entities/users/user.entity.ts`](diffhunk://#diff-29505a955d562ff7946ea8d0a7e7ecc5257c5e64785b05ccb28303339c7b8bcdL37-R37): Updated the default user role from `GENERAL_USER` to `PARTNER`.