### PR TITLE
fix missing role in create user

### DIFF
--- a/api/src/modules/auth/authentication.service.ts
+++ b/api/src/modules/auth/authentication.service.ts
@@ -57,7 +57,7 @@ export class AuthenticationService {
     createUser: CreateUserDto,
   ): Promise<{ newUser: User; plainTextPassword: string }> {
     // TODO: This is sync, check how to improve it
-    const { email, name, partnerName } = createUser;
+    const { email, name, partnerName, role } = createUser;
     const plainTextPassword = randomBytes(8).toString('hex');
     const passwordHash = await bcrypt.hash(plainTextPassword, 10);
     const existingUser = await this.usersService.findByEmail(createUser.email);
@@ -70,6 +70,7 @@ export class AuthenticationService {
       password: passwordHash,
       partnerName,
       isActive: false,
+      role,
     });
     this.eventBus.publish(
       new NewUserEvent(newUser.id, newUser.email, API_EVENT_TYPES.USER_CREATED),


### PR DESCRIPTION
This pull request introduces changes to the `AuthenticationService` and related tests to support user roles during user creation. The most important changes include updating the user creation logic to handle roles and adding corresponding test cases to ensure the functionality works as expected.

### Authentication Service Updates:
* Updated `createUser` method to include `role` in the user creation process. (`api/src/modules/auth/authentication.service.ts`, [[1]](diffhunk://#diff-d5531e6f14eff2e79ca54062b2a8760e45de6ae82f192f8eb4034d48f014e652L60-R60) [[2]](diffhunk://#diff-d5531e6f14eff2e79ca54062b2a8760e45de6ae82f192f8eb4034d48f014e652R73)

### Test Case Enhancements:
* Added `jest.clearAllMocks()` to reset mocks before each test run. (`api/test/integration/auth/create-user.spec.ts`, [api/test/integration/auth/create-user.spec.tsR21](diffhunk://#diff-df027b8f208a2d061d220bf2f116b4eb64de03e0951132205b5fe5068e0a077cR21))
* Modified existing test to check if the role is set to `PARTNER` when not provided. (`api/test/integration/auth/create-user.spec.ts`, [[1]](diffhunk://#diff-df027b8f208a2d061d220bf2f116b4eb64de03e0951132205b5fe5068e0a077cL74-R75) [[2]](diffhunk://#diff-df027b8f208a2d061d220bf2f116b4eb64de03e0951132205b5fe5068e0a077cR98-R123)
* Added a new test to verify that an admin can register another admin by explicitly setting the role. (`api/test/integration/auth/create-user.spec.ts`, [api/test/integration/auth/create-user.spec.tsR98-R123](diffhunk://#diff-df027b8f208a2d061d220bf2f116b4eb64de03e0951132205b5fe5068e0a077cR98-R123))