### PR TITLE
[N/A] omits totalCost filtering projects

### DIFF
--- a/client/src/containers/projects/table/utils.ts
+++ b/client/src/containers/projects/table/utils.ts
@@ -5,16 +5,17 @@ import { filtersSchema } from "@/app/(projects)/url-store";
 
 export const NO_DATA: Project[] = [];
 
+type OMITTED_FILTERS = "totalCost";
+
 export const filtersToQueryParams = (
-  filters: z.infer<typeof filtersSchema>,
+  filters: Omit<z.infer<typeof filtersSchema>, OMITTED_FILTERS>,
 ) => {
-  return Object.keys(filters)
-    .filter((key) => key !== "keyword")
-    .reduce(
-      (acc, key) => ({
-        ...acc,
-        [`filter[${key}]`]: filters[key as keyof typeof filters],
-      }),
-      {},
-    );
+  return Object.keys(filters).reduce(
+    (acc, key) => ({
+      ...acc,
+      [`filter[${key}]`]:
+        filters[key as keyof Omit<typeof filters, OMITTED_FILTERS>],
+    }),
+    {},
+  );
 };

--- a/client/src/containers/projects/table/view/key-costs/index.tsx
+++ b/client/src/containers/projects/table/view/key-costs/index.tsx
@@ -57,13 +57,14 @@ export function KeyCostsTable() {
     pagination,
   }).queryKey;
 
-  console.log(TABLE_COLUMNS[0]);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { totalCost, ...filtersWithoutTotalCost } = filters;
 
   const { data, isSuccess } = client.projects.getProjects.useQuery(
     queryKey,
     {
       query: {
-        ...filtersToQueryParams(filters),
+        ...filtersToQueryParams(filtersWithoutTotalCost),
         fields: TABLE_COLUMNS.map((column) => column.accessorKey),
         ...(sorting.length > 0 && {
           sort: sorting.map((sort) => `${sort.desc ? "" : "-"}${sort.id}`),

--- a/client/src/containers/projects/table/view/overview/index.tsx
+++ b/client/src/containers/projects/table/view/overview/index.tsx
@@ -59,11 +59,14 @@ export function OverviewTable() {
 
   const columnsBasedOnFilters = columns(filters);
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { totalCost, ...filtersWithoutTotalCost } = filters;
+
   const { data, isSuccess } = client.projects.getProjects.useQuery(
     queryKey,
     {
       query: {
-        ...filtersToQueryParams(filters),
+        ...filtersToQueryParams(filtersWithoutTotalCost),
         fields: columnsBasedOnFilters.map((column) => column.accessorKey),
         ...(sorting.length > 0 && {
           sort: sorting.map((sort) => `${sort.desc ? "" : "-"}${sort.id}`),

--- a/client/src/containers/projects/table/view/scorecard-prioritization/index.tsx
+++ b/client/src/containers/projects/table/view/scorecard-prioritization/index.tsx
@@ -57,11 +57,14 @@ export function ScoredCardPrioritizationTable() {
     pagination,
   }).queryKey;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { totalCost, ...filtersWithoutTotalCost } = filters;
+
   const { data, isSuccess } = client.projects.getProjects.useQuery(
     queryKey,
     {
       query: {
-        ...filtersToQueryParams(filters),
+        ...filtersToQueryParams(filtersWithoutTotalCost),
         fields: TABLE_COLUMNS.map((column) => column.accessorKey),
         ...(sorting.length > 0 && {
           sort: sorting.map((sort) => `${sort.desc ? "" : "-"}${sort.id}`),


### PR DESCRIPTION
This pull request focuses on updating the filtering logic across several components to omit the `totalCost` filter when querying project data. The changes ensure that the `totalCost` filter is excluded from the query parameters, preventing unnecessary data from being sent to the backend.

### Filtering Logic Updates:

* [`client/src/containers/projects/table/utils.ts`](diffhunk://#diff-cdf9af386ca932d7added5e37a0ac06075bb5f76281d3f91c5c30899a0432240R8-R17): Introduced a new type `OMITTED_FILTERS` and modified the `filtersToQueryParams` function to exclude `totalCost` from the filters.

* [`client/src/containers/projects/table/view/key-costs/index.tsx`](diffhunk://#diff-388880f28b9d7e3c1f0d60ee5cb9e77b0854836636560d7f4e7c57d23be8a674L60-R67): Updated the `KeyCostsTable` component to exclude `totalCost` from the filters before calling `filtersToQueryParams`.

* [`client/src/containers/projects/table/view/overview/index.tsx`](diffhunk://#diff-d8139c0d0c5b0968eb16eb7631bd26e740920b66c58546f53d0083c0eb7191b9R62-R69): Updated the `OverviewTable` component to exclude `totalCost` from the filters before calling `filtersToQueryParams`.

* [`client/src/containers/projects/table/view/scorecard-prioritization/index.tsx`](diffhunk://#diff-f33fd95f7935dd29c3a9e6266b31d418dff5b1dbda8e51397baf4504f5837296R60-R67): Updated the `ScoredCardPrioritizationTable` component to exclude `totalCost` from the filters before calling `filtersToQueryParams`.