### PR TITLE
basic endpoint to get default cost inputs for custom project creation

### DIFF
--- a/api/src/modules/custom-projects/custom-projects.controller.ts
+++ b/api/src/modules/custom-projects/custom-projects.controller.ts
@@ -42,6 +42,17 @@ export class CustomProjectsController {
     );
   }
 
+  @TsRestHandler(customProjectContract.getDefaultCostInputs)
+  async getCostInputs(): Promise<ControllerResponse> {
+    return tsRestHandler(
+      customProjectContract.getDefaultCostInputs,
+      async ({ query }) => {
+        const data = await this.customProjects.getDefaultCostInputs(query);
+        return { body: { data }, status: HttpStatus.OK };
+      },
+    );
+  }
+
   @TsRestHandler(customProjectContract.createCustomProject)
   async create(
     @Body(new ValidationPipe({ enableDebugMessages: true, transform: true }))

--- a/api/src/modules/custom-projects/custom-projects.service.ts
+++ b/api/src/modules/custom-projects/custom-projects.service.ts
@@ -8,6 +8,8 @@ import { CalculationEngine } from '@api/modules/calculations/calculation.engine'
 import { CustomProjectFactory } from '@api/modules/custom-projects/custom-project.factory';
 import { EMISSION_FACTORS_TIER_TYPES } from '@shared/entities/carbon-inputs/emission-factors.entity';
 import { ConservationCostCalculator } from '@api/modules/calculations/conservation-cost.calculator';
+import { DefaultCostInputsDto } from '@shared/dtos/custom-projects/default-cost-inputs.dto';
+import { GetDefaultCostInputsDto } from '@shared/dtos/custom-projects/get-default-cost-inputs.dto';
 
 @Injectable()
 export class CustomProjectsService extends AppBaseService<
@@ -61,5 +63,11 @@ export class CustomProjectsService extends AppBaseService<
       summary: calculator.getSummary(),
       yearBreakdown: calculator.getYearlyCostBreakdown(),
     };
+  }
+
+  async getDefaultCostInputs(
+    dto: GetDefaultCostInputsDto,
+  ): Promise<DefaultCostInputsDto> {
+    return this.calculationEngine.getDefaultCostInputs(dto);
   }
 }

--- a/api/test/integration/custom-projects/custom-projects-setup.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-setup.spec.ts
@@ -1,5 +1,7 @@
 import { TestManager } from '../../utils/test-manager';
 import { customProjectContract } from '@shared/contracts/custom-projects.contract';
+import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
+import { ACTIVITY } from '@shared/entities/activity.enum';
 
 describe('Create Custom Projects - Setup', () => {
   let testManager: TestManager;
@@ -31,5 +33,35 @@ describe('Create Custom Projects - Setup', () => {
       .get(customProjectContract.getDefaultAssumptions.path);
 
     expect(response.body.data).toHaveLength(18);
+  });
+
+  test('Should return default cost inputs given required filters', async () => {
+    const response = await testManager
+      .request()
+      .get(customProjectContract.getDefaultCostInputs.path)
+      .query({
+        countryCode: 'IND',
+        ecosystem: ECOSYSTEM.MANGROVE,
+        activity: ACTIVITY.CONSERVATION,
+      });
+
+    expect(response.body.data).toMatchObject({
+      feasibilityAnalysis: '50000',
+      conservationPlanningAndAdmin: '166766.66666666666',
+      dataCollectionAndFieldCost: '26666.666666666668',
+      communityRepresentation: '67633.33333333333',
+      blueCarbonProjectPlanning: '100000',
+      establishingCarbonRights: '46666.666666666664',
+      financingCost: '0.05',
+      validation: '50000',
+      implementationLaborHybrid: 'NaN',
+      monitoring: '8400',
+      maintenance: '0.0833',
+      carbonStandardFees: '0.2',
+      communityBenefitSharingFund: '0.5',
+      baselineReassessment: '40000',
+      mrv: '75000',
+      longTermProjectOperatingCost: '22200',
+    });
   });
 });

--- a/shared/contracts/custom-projects.contract.ts
+++ b/shared/contracts/custom-projects.contract.ts
@@ -4,6 +4,8 @@ import { Country } from "@shared/entities/country.entity";
 import { ModelAssumptions } from "@shared/entities/model-assumptions.entity";
 import { CustomProject } from "@shared/entities/custom-project.entity";
 import { CreateCustomProjectDto } from "@api/modules/custom-projects/dto/create-custom-project-dto";
+import { DefaultCostInputsDto } from "@shared/dtos/custom-projects/default-cost-inputs.dto";
+import { GetDefaultCostInputsSchema } from "@shared/schemas/custom-projects/get-cost-inputs.schema";
 
 // TODO: This is a scaffold. We need to define types for responses, zod schemas for body and query param validation etc.
 
@@ -26,6 +28,14 @@ export const customProjectContract = contract.router({
     },
     summary: "Get default model assumptions",
   },
+  getDefaultCostInputs: {
+    method: "GET",
+    path: "/custom-projects/cost-inputs",
+    responses: {
+      200: contract.type<ApiResponse<DefaultCostInputsDto>>(),
+    },
+    query: GetDefaultCostInputsSchema,
+  },
   createCustomProject: {
     method: "POST",
     path: "/custom-projects",
@@ -34,14 +44,6 @@ export const customProjectContract = contract.router({
     },
     body: contract.type<CreateCustomProjectDto>(),
   },
-  // createConservationCustomProject: {
-  //   method: "POST",
-  //   path: "/custom-projects/conservation",
-  //   responses: {
-  //     201: contract.type<ApiResponse<CustomProject>>(),
-  //   },
-  //   body: contract.type<CreateCustomProjectDto>(),
-  // },
 });
 
 // TODO: Due to dificulties crafting a deeply nested conditional schema, I will go forward with nestjs custom validation pipe for now

--- a/shared/dtos/custom-projects/default-cost-inputs.dto.ts
+++ b/shared/dtos/custom-projects/default-cost-inputs.dto.ts
@@ -1,0 +1,21 @@
+import { BaseDataView } from "@shared/entities/base-data.view";
+
+export type DefaultCostInputsDto = Pick<
+  BaseDataView,
+  | "feasibilityAnalysis"
+  | "conservationPlanningAndAdmin"
+  | "dataCollectionAndFieldCost"
+  | "communityRepresentation"
+  | "blueCarbonProjectPlanning"
+  | "establishingCarbonRights"
+  | "validation"
+  | "implementationLaborHybrid"
+  | "monitoring"
+  | "maintenance"
+  | "communityBenefitSharingFund"
+  | "carbonStandardFees"
+  | "baselineReassessment"
+  | "mrv"
+  | "longTermProjectOperatingCost"
+  | "financingCost"
+>;

--- a/shared/dtos/custom-projects/get-default-cost-inputs.dto.ts
+++ b/shared/dtos/custom-projects/get-default-cost-inputs.dto.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { GetDefaultCostInputsSchema } from "@shared/schemas/custom-projects/get-cost-inputs.schema";
+
+export type GetDefaultCostInputsDto = z.infer<
+  typeof GetDefaultCostInputsSchema
+>;

--- a/shared/schemas/custom-projects/get-cost-inputs.schema.ts
+++ b/shared/schemas/custom-projects/get-cost-inputs.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
+import { ACTIVITY } from "@shared/entities/activity.enum";
+
+export const GetDefaultCostInputsSchema = z.object({
+  countryCode: z.string().min(3).max(3),
+  ecosystem: z.nativeEnum(ECOSYSTEM),
+  activity: z.nativeEnum(ACTIVITY),
+});


### PR DESCRIPTION
This pull request introduces several updates to the custom projects module, mainly focusing on adding functionality to retrieve default cost inputs. The changes include new methods, DTOs, and tests to support this feature.

### New functionality for retrieving default cost inputs:

* [`api/src/modules/calculations/calculation.engine.ts`](diffhunk://#diff-3fadd62658222f544e8089accf3574de621be7416f7d97e20ca45c7d3b127e37L56-R92): Added a method `getDefaultCostInputs` to fetch default cost inputs based on country, activity, and ecosystem.
* [`api/src/modules/custom-projects/custom-projects.controller.ts`](diffhunk://#diff-cc9c8bff38622ff15dd4ba62ed57da7aa1af212d09902ea07100a2182a45147eR45-R55): Introduced a new endpoint `getCostInputs` to handle requests for default cost inputs.
* [`api/src/modules/custom-projects/custom-projects.service.ts`](diffhunk://#diff-a450b42f83aa743e906c235e1dbcc649854328c6951985e9bcaf6a40b6029eacR67-R72): Added a method `getDefaultCostInputs` to call the corresponding method in `CalculationEngine`.

### Data transfer objects and schemas:

* [`shared/dtos/custom-projects/default-cost-inputs.dto.ts`](diffhunk://#diff-0f130acf2998111a00d99efdcab1d63e566ea686e4734035419c9f166bfef76aR1-R21): Created a new DTO `DefaultCostInputsDto` to define the structure of default cost inputs.
* [`shared/dtos/custom-projects/get-default-cost-inputs.dto.ts`](diffhunk://#diff-95f7b682815c07cabdfb4fb808a536e187d3a8577bf6249621ae7c3e43619ff0R1-R6): Added a new DTO `GetDefaultCostInputsDto` to handle input validation for the new endpoint.
* [`shared/schemas/custom-projects/get-cost-inputs.schema.ts`](diffhunk://#diff-e8ea01d5f086d2ba48b6b28695d2e8abdaf5062512e6ee6ce6853b9217a4952aR1-R9): Defined a new schema `GetDefaultCostInputsSchema` for validating the query parameters.

### Tests:

* [`api/test/integration/custom-projects/custom-projects-setup.spec.ts`](diffhunk://#diff-b91e7fa38b414665b5837150fd1bf381a04a1affd5a12b2835fc7edc6ef8cff3R37-R66): Added an integration test to verify the new functionality for retrieving default cost inputs.