### PR TITLE
[N/A] fixes sync of cost value with query params

### DIFF
--- a/client/src/containers/overview/filters/index.tsx
+++ b/client/src/containers/overview/filters/index.tsx
@@ -141,17 +141,6 @@ export default function ProjectsFilters() {
   );
 
   useEffect(() => {
-    const resetCosts = async () => {
-      await setFilters((prev) => ({
-        ...prev,
-        costRange: INITIAL_COST_RANGE[filters.costRangeSelector],
-      }));
-    };
-
-    resetCosts();
-  }, [filters.costRangeSelector, setFilters]);
-
-  useEffect(() => {
     setCostValuesState([
       filters.costRange[0] || INITIAL_COST_RANGE[filters.costRangeSelector][0],
       filters.costRange[1] || INITIAL_COST_RANGE[filters.costRangeSelector][1],

--- a/client/src/containers/overview/header/parameters/index.tsx
+++ b/client/src/containers/overview/header/parameters/index.tsx
@@ -9,6 +9,8 @@ import { FILTER_KEYS } from "@/app/(overview)/constants";
 import { useGlobalFilters } from "@/app/(overview)/url-store";
 import { filtersSchema } from "@/app/(overview)/url-store";
 
+import { INITIAL_COST_RANGE } from "@/containers/overview/filters/constants";
+
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -76,7 +78,13 @@ export default function ParametersProjects() {
     v: string,
     parameter: keyof Omit<z.infer<typeof filtersSchema>, "keyword">,
   ) => {
-    await setFilters((prev) => ({ ...prev, [parameter]: v }));
+    await setFilters((prev) => ({
+      ...prev,
+      [parameter]: v,
+      ...(parameter === "costRangeSelector" && {
+        costRange: INITIAL_COST_RANGE[v as COST_TYPE_SELECTOR],
+      }),
+    }));
   };
 
   return (


### PR DESCRIPTION
This pull request includes several changes to the `client/src/containers/overview` directory, focusing on improving the handling of cost range filters in the `ProjectsFilters` and `ParametersProjects` components. Key changes include the removal of an unnecessary `useEffect` hook and the addition of logic to reset cost ranges when a selector is changed.

Changes to `ProjectsFilters` component:

* Removed the `useEffect` hook that reset cost ranges on component mount, as it was redundant.

Changes to `ParametersProjects` component:

* Added import for `INITIAL_COST_RANGE` to ensure cost ranges are properly reset.
* Updated the `setFilters` function to reset the `costRange` when the `costRangeSelector` parameter is changed.