### PR TITLE
fix/client/overview-units

### DIFF
--- a/client/src/containers/overview/filters/index.tsx
+++ b/client/src/containers/overview/filters/index.tsx
@@ -298,7 +298,7 @@ export default function ProjectsFilters() {
         </ul>
       </div>
       <div className="flex flex-col gap-3">
-        <Label htmlFor="costs">Cost ($)</Label>
+        <Label htmlFor="costs">Cost ($/tCO2e)</Label>
         <RangeSlider
           defaultValue={[
             filters.costRange[0] ||
@@ -324,7 +324,9 @@ export default function ProjectsFilters() {
       </div>
 
       <div className="flex flex-col gap-3">
-        <Label htmlFor="abatement_potential">Abatement Potential ($)</Label>
+        <Label htmlFor="abatement_potential">
+          Abatement Potential (tCO2e/yr)
+        </Label>
         <RangeSlider
           defaultValue={[
             filters.abatementPotentialRange[0] ||

--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -2,6 +2,8 @@ import { ProjectType } from "@shared/contracts/projects.contract";
 import { createColumnHelper } from "@tanstack/react-table";
 import { z } from "zod";
 
+import { formatNumber } from "@/lib/format";
+
 import { filtersSchema } from "@/app/(overview)/url-store";
 
 const columnHelper = createColumnHelper<Partial<ProjectType>>();
@@ -21,17 +23,41 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
     {
       enableSorting: true,
       header: () => <span>Cost $/tCo2</span>,
+      cell: (props) => {
+        const value = props.getValue();
+        if (value === null || value === undefined) {
+          return "-";
+        }
+
+        return formatNumber(value);
+      },
     },
   ),
   columnHelper.accessor("abatementPotential", {
     enableSorting: true,
     header: () => <span>Abatement potential</span>,
+    cell: (props) => {
+      const value = props.getValue();
+      if (value === null || value === undefined) {
+        return "-";
+      }
+
+      return formatNumber(value);
+    },
   }),
   columnHelper.accessor(
     filters.costRangeSelector === "npv" ? "totalCostNPV" : "totalCost",
     {
       enableSorting: true,
       header: () => <span>Total Cost (CapEx + OpEx)</span>,
+      cell: (props) => {
+        const value = props.getValue();
+        if (value === null || value === undefined) {
+          return "-";
+        }
+
+        return formatNumber(value);
+      },
     },
   ),
 ];


### PR DESCRIPTION
This pull request includes changes to the `ProjectsFilters` component and the `columns` configuration in the `overview` table view. The main focus is on updating labels for better clarity and formatting cell values in the table.

Label updates:

* [`client/src/containers/overview/filters/index.tsx`](diffhunk://#diff-a2f0b8fb946d416d1de6ac901104e67c3959693545dc401524e71e49e57019f7L301-R301): Updated the label for cost to "Cost ($/tCO2e)" and the label for abatement potential to "Abatement Potential (tCO2e/yr)." [[1]](diffhunk://#diff-a2f0b8fb946d416d1de6ac901104e67c3959693545dc401524e71e49e57019f7L301-R301) [[2]](diffhunk://#diff-a2f0b8fb946d416d1de6ac901104e67c3959693545dc401524e71e49e57019f7L327-R329)

Cell value formatting:

* [`client/src/containers/overview/table/view/overview/columns.tsx`](diffhunk://#diff-a7ee66cfc298127614d16796d1d774700de6d3a3ee2e7ee81b9f2c4eeb70915fR5-R6): Added `formatNumber` import to format cell values.
* [`client/src/containers/overview/table/view/overview/columns.tsx`](diffhunk://#diff-a7ee66cfc298127614d16796d1d774700de6d3a3ee2e7ee81b9f2c4eeb70915fR26-R60): Updated the cell rendering for cost, abatement potential, and total cost columns to use `formatNumber` for better readability.