### PR TITLE
Fix/overridable cost inputs

### DIFF
--- a/api/src/modules/calculations/conservation-cost.calculator.ts
+++ b/api/src/modules/calculations/conservation-cost.calculator.ts
@@ -3,8 +3,10 @@ import { DEFAULT_STUFF } from '@api/modules/custom-projects/project-config.inter
 import { BaseIncrease } from '@shared/entities/base-increase.entity';
 import { BaseSize } from '@shared/entities/base-size.entity';
 import { SequestrationRatesCalculator } from '@api/modules/calculations/sequestration-rate.calculator';
-import { RESTORATION_ACTIVITY_SUBTYPE } from '@shared/entities/projects.entity';
-import { ACTIVITY } from '@shared/entities/activity.enum';
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from '@shared/entities/activity.enum';
 import { RevenueProfitCalculator } from '@api/modules/calculations/revenue-profit.calculators';
 import { Finance } from 'financejs';
 

--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -165,8 +165,9 @@ export class CostCalculator {
     const totalBaseCost = this.getTotalBaseCost(
       COST_KEYS.COMMUNITY_REPRESENTATION,
     );
-    const projectDevelopmentType =
-      this.projectInput.costInputs.otherCommunityCashFlow;
+    // TODO: TO avoid type crash, fix after cost calculator has all required inputs
+    const projectDevelopmentType = 'Development';
+    //  this.projectInput.costInputs.otherCommunityCashFlow;
     const initialCost =
       projectDevelopmentType === PROJECT_DEVELOPMENT_TYPE.DEVELOPMENT
         ? 0

--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -6,7 +6,7 @@ import { RestorationProjectInput } from '@api/modules/custom-projects/input-fact
 import { BaseSize } from '@shared/entities/base-size.entity';
 import { BaseIncrease } from '@shared/entities/base-increase.entity';
 import {
-  CostInputs,
+  OverridableCostInputs,
   PROJECT_DEVELOPMENT_TYPE,
 } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 
@@ -29,7 +29,7 @@ type CostPlanMap = {
 //   ) {}
 // }
 
-type CostPlans = Record<keyof CostInputs, CostPlanMap>;
+type CostPlans = Record<keyof OverridableCostInputs, CostPlanMap>;
 
 export enum COST_KEYS {
   FEASIBILITY_ANALYSIS = 'feasibilityAnalysis',

--- a/api/src/modules/calculations/data.repository.ts
+++ b/api/src/modules/calculations/data.repository.ts
@@ -162,8 +162,13 @@ export class DataRepository extends Repository<BaseDataView> {
     if (dto.activity === ACTIVITY.CONSERVATION) {
       queryBuilder.select('0', 'implementationLabor');
     }
+    // Since we are using aliases and selecting columns that are not in the entity, the transformer does not get triggered
+    // So we manually parse the values to float
     for (const name of COMMON_OVERRIDABLE_COST_INPUTS) {
-      queryBuilder.addSelect(queryBuilder.alias + '.' + name, name);
+      queryBuilder.addSelect(
+        queryBuilder.alias + '.' + name + ' :: float',
+        name,
+      );
     }
 
     return queryBuilder;

--- a/api/src/modules/calculations/data.repository.ts
+++ b/api/src/modules/calculations/data.repository.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import { ACTIVITY } from '@shared/entities/activity.enum';
-import { GetDefaultCostInputsDto } from '@shared/dtos/custom-projects/get-default-cost-inputs.dto';
+import { GetOverridableCostInputs } from '@shared/dtos/custom-projects/get-overridable-cost-inputs.dto';
 import { OverridableCostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 import { BaseSize } from '@shared/entities/base-size.entity';
 import { BaseIncrease } from '@shared/entities/base-increase.entity';
@@ -69,8 +69,8 @@ export class DataRepository extends Repository<BaseDataView> {
     return defaultCarbonInputs;
   }
 
-  async getDefaultCostInputs(
-    dto: GetDefaultCostInputsDto,
+  async getOverridableCostInputs(
+    dto: GetOverridableCostInputs,
   ): Promise<OverridableCostInputs> {
     const { countryCode, activity, ecosystem } = dto;
     // The coming CostInput has a implementation labor property which does not exist in the BaseDataView entity, so we use a partial type to avoid the error

--- a/api/src/modules/calculations/data.repository.ts
+++ b/api/src/modules/calculations/data.repository.ts
@@ -5,7 +5,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import { ACTIVITY } from '@shared/entities/activity.enum';
 import { GetDefaultCostInputsDto } from '@shared/dtos/custom-projects/get-default-cost-inputs.dto';
-import { CostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
+import { OverridableCostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 import { BaseSize } from '@shared/entities/base-size.entity';
 import { BaseIncrease } from '@shared/entities/base-increase.entity';
 
@@ -71,10 +71,10 @@ export class DataRepository extends Repository<BaseDataView> {
 
   async getDefaultCostInputs(
     dto: GetDefaultCostInputsDto,
-  ): Promise<CostInputs> {
+  ): Promise<OverridableCostInputs> {
     const { countryCode, activity, ecosystem } = dto;
     // The coming CostInput has a implementation labor property which does not exist in the BaseDataView entity, so we use a partial type to avoid the error
-    const costInputs: Partial<CostInputs> = await this.findOne({
+    const costInputs: Partial<OverridableCostInputs> = await this.findOne({
       where: { countryCode, activity, ecosystem },
       select: [
         'feasibilityAnalysis',
@@ -84,7 +84,10 @@ export class DataRepository extends Repository<BaseDataView> {
         'blueCarbonProjectPlanning',
         'establishingCarbonRights',
         'validation',
+        // TODO: this has to be filtered by sub-activity
         'implementationLaborHybrid',
+        'implementationLaborPlanting',
+        'implementationLaborHydrology',
         'monitoring',
         'maintenance',
         'communityBenefitSharingFund',
@@ -93,9 +96,6 @@ export class DataRepository extends Repository<BaseDataView> {
         'mrv',
         'longTermProjectOperatingCost',
         'financingCost',
-        'implementationLaborPlanting',
-        'implementationLaborHydrology',
-        'otherCommunityCashFlow',
       ],
     });
     if (!costInputs) {
@@ -103,7 +103,7 @@ export class DataRepository extends Repository<BaseDataView> {
         `Could not find default Cost Inputs for country ${countryCode}, activity ${activity} and ecosystem ${ecosystem}`,
       );
     }
-    return costInputs as CostInputs;
+    return costInputs as OverridableCostInputs;
   }
 
   async getBaseIncreaseAndSize(params: {

--- a/api/src/modules/calculations/sequestration-rate.calculator.ts
+++ b/api/src/modules/calculations/sequestration-rate.calculator.ts
@@ -1,6 +1,9 @@
 import { ConservationProject } from '@api/modules/custom-projects/conservation.project';
-import { ACTIVITY } from '@shared/entities/activity.enum';
-import { RESTORATION_ACTIVITY_SUBTYPE } from '@shared/entities/projects.entity';
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from '@shared/entities/activity.enum';
+
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/api/src/modules/custom-projects/custom-projects.service.ts
+++ b/api/src/modules/custom-projects/custom-projects.service.ts
@@ -6,7 +6,7 @@ import { Repository } from 'typeorm';
 import { CustomProject } from '@shared/entities/custom-project.entity';
 import { CalculationEngine } from '@api/modules/calculations/calculation.engine';
 import { CustomProjectInputFactory } from '@api/modules/custom-projects/input-factory/custom-project-input.factory';
-import { GetDefaultCostInputsDto } from '@shared/dtos/custom-projects/get-default-cost-inputs.dto';
+import { GetOverridableCostInputs } from '@shared/dtos/custom-projects/get-overridable-cost-inputs.dto';
 import { DataRepository } from '@api/modules/calculations/data.repository';
 import { OverridableCostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 import { CostCalculator } from '@api/modules/calculations/cost.calculator';
@@ -63,9 +63,9 @@ export class CustomProjectsService extends AppBaseService<
   }
 
   async getDefaultCostInputs(
-    dto: GetDefaultCostInputsDto,
+    dto: GetOverridableCostInputs,
   ): Promise<OverridableCostInputs> {
-    return this.dataRepository.getDefaultCostInputs(dto);
+    return this.dataRepository.getOverridableCostInputs(dto);
   }
 
   async getDefaultAssumptions(dto: GetOverridableAssumptionsDTO) {

--- a/api/src/modules/custom-projects/custom-projects.service.ts
+++ b/api/src/modules/custom-projects/custom-projects.service.ts
@@ -8,7 +8,7 @@ import { CalculationEngine } from '@api/modules/calculations/calculation.engine'
 import { CustomProjectInputFactory } from '@api/modules/custom-projects/input-factory/custom-project-input.factory';
 import { GetDefaultCostInputsDto } from '@shared/dtos/custom-projects/get-default-cost-inputs.dto';
 import { DataRepository } from '@api/modules/calculations/data.repository';
-import { CostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
+import { OverridableCostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 import { CostCalculator } from '@api/modules/calculations/cost.calculator';
 import { GetOverridableAssumptionsDTO } from '@shared/dtos/custom-projects/get-overridable-assumptions.dto';
 import { AssumptionsRepository } from '@api/modules/calculations/assumptions.repository';
@@ -64,7 +64,7 @@ export class CustomProjectsService extends AppBaseService<
 
   async getDefaultCostInputs(
     dto: GetDefaultCostInputsDto,
-  ): Promise<CostInputs> {
+  ): Promise<OverridableCostInputs> {
     return this.dataRepository.getDefaultCostInputs(dto);
   }
 

--- a/api/src/modules/custom-projects/dto/create-custom-project-dto.ts
+++ b/api/src/modules/custom-projects/dto/create-custom-project-dto.ts
@@ -12,7 +12,7 @@ import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import { ConservationProjectParamDto } from '@api/modules/custom-projects/dto/conservation-project-params.dto';
 import { RestorationProjectParamsDto } from '@api/modules/custom-projects/dto/restoration-project-params.dto';
 import { OverridableAssumptions } from '@api/modules/custom-projects/dto/project-assumptions.dto';
-import { CostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
+import { OverridableCostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 import { ProjectParamsValidator } from '@api/modules/custom-projects/validation/project-params.validator';
 import { Transform, Type } from 'class-transformer';
 
@@ -55,8 +55,8 @@ export class CreateCustomProjectDto {
     message: 'Cost inputs are required to create a custom project',
   })
   @ValidateNested()
-  @Type(() => CostInputs)
-  costInputs: CostInputs;
+  @Type(() => OverridableCostInputs)
+  costInputs: OverridableCostInputs;
 
   @IsNotEmpty()
   @Transform(injectEcosystemToParams)

--- a/api/src/modules/custom-projects/dto/project-cost-inputs.dto.ts
+++ b/api/src/modules/custom-projects/dto/project-cost-inputs.dto.ts
@@ -5,7 +5,7 @@ export enum PROJECT_DEVELOPMENT_TYPE {
   NON_DEVELOPMENT = 'Non-Development',
 }
 
-export class CostInputs {
+export class OverridableCostInputs {
   @IsNumber()
   financingCost: number;
 
@@ -54,6 +54,7 @@ export class CostInputs {
   @IsNumber()
   implementationLabor: number;
 
+  // TODO: this is not overridable, remove
   @IsEnum(PROJECT_DEVELOPMENT_TYPE)
   otherCommunityCashFlow: PROJECT_DEVELOPMENT_TYPE | string;
 }

--- a/api/src/modules/custom-projects/dto/project-cost-inputs.dto.ts
+++ b/api/src/modules/custom-projects/dto/project-cost-inputs.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsNumber } from 'class-validator';
+import { IsNumber } from 'class-validator';
 
 export enum PROJECT_DEVELOPMENT_TYPE {
   DEVELOPMENT = 'Development',
@@ -53,8 +53,4 @@ export class OverridableCostInputs {
 
   @IsNumber()
   implementationLabor: number;
-
-  // TODO: this is not overridable, remove
-  @IsEnum(PROJECT_DEVELOPMENT_TYPE)
-  otherCommunityCashFlow: PROJECT_DEVELOPMENT_TYPE | string;
 }

--- a/api/src/modules/custom-projects/input-factory/conservation-project.input.ts
+++ b/api/src/modules/custom-projects/input-factory/conservation-project.input.ts
@@ -1,7 +1,7 @@
 import { ACTIVITY } from '@shared/entities/activity.enum';
 import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import { CARBON_REVENUES_TO_COVER } from '@api/modules/custom-projects/dto/create-custom-project-dto';
-import { CostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
+import { OverridableCostInputs } from '@api/modules/custom-projects/dto/project-cost-inputs.dto';
 import { OverridableAssumptions } from '@api/modules/custom-projects/dto/project-assumptions.dto';
 import {
   ConservationProjectParamDto,
@@ -36,7 +36,7 @@ export class ConservationProjectInput {
     emissionFactorSoc: 0,
   };
 
-  costInputs: CostInputs = new CostInputs();
+  costInputs: OverridableCostInputs = new OverridableCostInputs();
 
   modelAssumptions: OverridableAssumptions = new OverridableAssumptions();
 
@@ -75,7 +75,7 @@ export class ConservationProjectInput {
     return this;
   }
 
-  setCostInputs(costInputs: CostInputs): this {
+  setCostInputs(costInputs: OverridableCostInputs): this {
     this.costInputs = costInputs;
     return this;
   }

--- a/api/src/modules/custom-projects/project-config.interface.ts
+++ b/api/src/modules/custom-projects/project-config.interface.ts
@@ -1,6 +1,8 @@
 import { BaseDataView } from '@shared/entities/base-data.view';
-import { ACTIVITY } from '@shared/entities/activity.enum';
-import { RESTORATION_ACTIVITY_SUBTYPE } from '@shared/entities/projects.entity';
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from '@shared/entities/activity.enum';
 
 // TODO: This seems to be a mix of assumptions, base sizes and increases. Check with Data
 export const DEFAULT_STUFF = {

--- a/api/src/modules/custom-projects/restoration.project.ts
+++ b/api/src/modules/custom-projects/restoration.project.ts
@@ -1,4 +1,7 @@
-import { ACTIVITY } from '@shared/entities/activity.enum';
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from '@shared/entities/activity.enum';
 import {
   RestorationProjectConfig,
   DEFAULT_STUFF,
@@ -6,7 +9,6 @@ import {
 import { BaseDataView } from '@shared/entities/base-data.view';
 import { CostInputsDeprecated } from '@api/modules/custom-projects/cost-inputs.interface';
 import { ModelAssumptions } from '@shared/entities/model-assumptions.entity';
-import { RESTORATION_ACTIVITY_SUBTYPE } from '@shared/entities/projects.entity';
 
 export class RestorationProject {
   name: string;

--- a/api/src/modules/import/dtos/excel-projects.dto.ts
+++ b/api/src/modules/import/dtos/excel-projects.dto.ts
@@ -1,9 +1,9 @@
-import { ACTIVITY } from '@shared/entities/activity.enum';
-import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import {
-  PROJECT_PRICE_TYPE,
+  ACTIVITY,
   RESTORATION_ACTIVITY_SUBTYPE,
-} from '@shared/entities/projects.entity';
+} from '@shared/entities/activity.enum';
+import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
+import { PROJECT_PRICE_TYPE } from '@shared/entities/projects.entity';
 
 export type ExcelProjects = {
   project_name: string;

--- a/api/src/modules/import/services/entity.preprocessor.ts
+++ b/api/src/modules/import/services/entity.preprocessor.ts
@@ -1107,7 +1107,7 @@ export class EntityPreprocessor {
       project.countryCode = row.country_code;
       project.ecosystem = row.ecosystem;
       project.activity = row.activity;
-      project.activitySubtype = row.activity_type;
+      project.restorationActivity = row.activity_type;
       project.projectSize = row.project_size_ha;
       project.projectSizeFilter = row.project_size_filter;
       project.abatementPotential = row.aAbatement_potential;

--- a/api/test/integration/custom-projects/custom-projects-setup.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-setup.spec.ts
@@ -72,7 +72,7 @@ describe('Create Custom Projects - Setup', () => {
       establishingCarbonRights: 46666.666666666664,
       financingCost: 0.05,
       validation: 50000,
-      implementationLaborHybrid: null,
+      implementationLabor: 0,
       monitoring: 8400,
       maintenance: 0.0833,
       carbonStandardFees: 0.2,

--- a/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
+++ b/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
@@ -64,7 +64,7 @@ export function ScoredCardPrioritizationTable() {
         ...filtersToQueryParams(filters),
 
         filter: {
-          activitySubtype: [""],
+          restorationActivity: [""],
         },
         // fields: TABLE_COLUMNS.map((column) => column.accessorKey),
         // ...(sorting.length > 0 && {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -27,8 +27,9 @@ export default defineConfig({
       env: {
         NEXTAUTH_URL: APP_URL,
         NEXT_PUBLIC_API_URL: API_URL,
-        NEXTAUTH_SECRET: "WAzjpS46vFxp17TsRDU3FXo+TF0vrfy6uhCXwGMBUE8="
-      }
+        NEXTAUTH_SECRET: "WAzjpS46vFxp17TsRDU3FXo+TF0vrfy6uhCXwGMBUE8=",
+      },
+      timeout: 100000,
     },
   ],
   testDir: "./tests",
@@ -48,7 +49,6 @@ export default defineConfig({
     baseURL: APP_URL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
-
   },
   /* Configure projects for major browsers */
   projects: [

--- a/shared/contracts/custom-projects.contract.ts
+++ b/shared/contracts/custom-projects.contract.ts
@@ -5,7 +5,7 @@ import { ModelAssumptions } from "@shared/entities/model-assumptions.entity";
 import { CustomProject } from "@shared/entities/custom-project.entity";
 import { CreateCustomProjectDto } from "@api/modules/custom-projects/dto/create-custom-project-dto";
 import { GetDefaultCostInputsSchema } from "@shared/schemas/custom-projects/get-cost-inputs.schema";
-import { CostInputs } from "@api/modules/custom-projects/dto/project-cost-inputs.dto";
+import { OverridableCostInputs } from "@api/modules/custom-projects/dto/project-cost-inputs.dto";
 import { GetAssumptionsSchema } from "@shared/schemas/assumptions/get-assumptions.schema";
 
 const contract = initContract();
@@ -32,7 +32,7 @@ export const customProjectContract = contract.router({
     method: "GET",
     path: "/custom-projects/cost-inputs",
     responses: {
-      200: contract.type<ApiResponse<CostInputs>>(),
+      200: contract.type<ApiResponse<OverridableCostInputs>>(),
     },
     query: GetDefaultCostInputsSchema,
   },

--- a/shared/dtos/custom-projects/get-overridable-cost-inputs.dto.ts
+++ b/shared/dtos/custom-projects/get-overridable-cost-inputs.dto.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { GetDefaultCostInputsSchema } from "@shared/schemas/custom-projects/get-cost-inputs.schema";
 
-export type GetDefaultCostInputsDto = z.infer<
+export type GetOverridableCostInputs = z.infer<
   typeof GetDefaultCostInputsSchema
 >;

--- a/shared/entities/projects.entity.ts
+++ b/shared/entities/projects.entity.ts
@@ -9,7 +9,7 @@ import {
 
 import { Country } from "@shared/entities/country.entity";
 import { ECOSYSTEM } from "./ecosystem.enum";
-import { ACTIVITY } from "./activity.enum";
+import { ACTIVITY, RESTORATION_ACTIVITY_SUBTYPE } from "./activity.enum";
 
 export enum PROJECT_SIZE_FILTER {
   SMALL = "Small",
@@ -25,12 +25,6 @@ export enum PROJECT_PRICE_TYPE {
 export enum COST_TYPE_SELECTOR {
   TOTAL = "total",
   NPV = "npv",
-}
-
-export enum RESTORATION_ACTIVITY_SUBTYPE {
-  HYBRID = "Hybrid",
-  HYDROLOGY = "Hydrology",
-  PLANTING = "Planting",
 }
 
 @Entity("projects")
@@ -57,12 +51,12 @@ export class Project extends BaseEntity {
 
   // TODO: We need to make this a somehow enum, as a subactivity of restoration, that can be null for conservation, and can represent all restoration activities
   @Column({
-    name: "activity_subtype",
+    name: "restoration_activity",
     type: "varchar",
     length: 255,
     nullable: true,
   })
-  activitySubtype: RESTORATION_ACTIVITY_SUBTYPE;
+  restorationActivity: RESTORATION_ACTIVITY_SUBTYPE;
 
   @Column({ name: "project_size", type: "decimal" })
   projectSize: number;

--- a/shared/lib/entity-mocks.ts
+++ b/shared/lib/entity-mocks.ts
@@ -13,7 +13,7 @@ import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 
 export const createUser = async (
   dataSource: DataSource,
-  additionalData?: Partial<User>
+  additionalData?: Partial<User>,
 ): Promise<User> => {
   const salt = await genSalt();
   const usedPassword = additionalData?.password ?? "12345678";
@@ -30,7 +30,7 @@ export const createUser = async (
 
 export const createProject = async (
   dataSource: DataSource,
-  additionalData?: DeepPartial<Project>
+  additionalData?: DeepPartial<Project>,
 ): Promise<Project> => {
   const countries = await dataSource.getRepository(Country).find();
   if (!countries.length) {
@@ -41,7 +41,7 @@ export const createProject = async (
     countryCode: countries[0].code,
     activity: ACTIVITY.CONSERVATION,
     ecosystem: ECOSYSTEM.MANGROVE,
-    activitySubtype: RESTORATION_ACTIVITY_SUBTYPE.PLANTING,
+    restorationActivity: RESTORATION_ACTIVITY_SUBTYPE.PLANTING,
     projectSize: 100,
     projectSizeFilter: PROJECT_SIZE_FILTER.LARGE,
     abatementPotential: 100,

--- a/shared/lib/entity-mocks.ts
+++ b/shared/lib/entity-mocks.ts
@@ -5,10 +5,12 @@ import {
   Project,
   PROJECT_PRICE_TYPE,
   PROJECT_SIZE_FILTER,
-  RESTORATION_ACTIVITY_SUBTYPE,
 } from "@shared/entities/projects.entity";
 import { Country } from "@shared/entities/country.entity";
-import { ACTIVITY } from "@shared/entities/activity.enum";
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from "@shared/entities/activity.enum";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 
 export const createUser = async (

--- a/shared/schemas/custom-projects/get-cost-inputs.schema.ts
+++ b/shared/schemas/custom-projects/get-cost-inputs.schema.ts
@@ -2,8 +2,34 @@ import { z } from "zod";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 import { ACTIVITY } from "@shared/entities/activity.enum";
 
-export const GetDefaultCostInputsSchema = z.object({
-  countryCode: z.string().min(3).max(3),
-  ecosystem: z.nativeEnum(ECOSYSTEM),
-  activity: z.nativeEnum(ACTIVITY),
-});
+export const GetDefaultCostInputsSchema = z
+  .object({
+    countryCode: z.string().min(3).max(3),
+    ecosystem: z.nativeEnum(ECOSYSTEM),
+    activity: z.nativeEnum(ACTIVITY),
+    restorationActivity: z.nativeEnum(ECOSYSTEM).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.activity === ACTIVITY.CONSERVATION &&
+      data.restorationActivity !== undefined
+    ) {
+      ctx.addIssue({
+        path: ["restorationActivitySubtype"],
+        message:
+          "restorationActivitySubtype should not be defined when activity is CONSERVATION",
+        code: z.ZodIssueCode.custom,
+      });
+    }
+    if (
+      data.activity === ACTIVITY.RESTORATION &&
+      data.restorationActivity === undefined
+    ) {
+      ctx.addIssue({
+        path: ["restorationActivitySubtype"],
+        message:
+          "restorationActivitySubtype is required when activity is RESTORATION",
+        code: z.ZodIssueCode.custom,
+      });
+    }
+  });

--- a/shared/schemas/custom-projects/get-cost-inputs.schema.ts
+++ b/shared/schemas/custom-projects/get-cost-inputs.schema.ts
@@ -1,13 +1,16 @@
 import { z } from "zod";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
-import { ACTIVITY } from "@shared/entities/activity.enum";
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from "@shared/entities/activity.enum";
 
 export const GetDefaultCostInputsSchema = z
   .object({
     countryCode: z.string().min(3).max(3),
     ecosystem: z.nativeEnum(ECOSYSTEM),
     activity: z.nativeEnum(ACTIVITY),
-    restorationActivity: z.nativeEnum(ECOSYSTEM).optional(),
+    restorationActivity: z.nativeEnum(RESTORATION_ACTIVITY_SUBTYPE).optional(),
   })
   .superRefine((data, ctx) => {
     if (


### PR DESCRIPTION
This pull request involves several significant changes across multiple files related to the calculation of conservation costs and the handling of cost inputs. The primary focus is on renaming and restructuring cost input types and updating related methods and imports.

### Key Changes:

#### Refactoring Cost Inputs:
* Renamed `CostInputs` to `OverridableCostInputs` and updated all references accordingly. This change affects various files including `project-cost-inputs.dto.ts`, `create-custom-project-dto.ts`, and `conservation-project.input.ts`. ([api/src/modules/custom-projects/dto/project-cost-inputs.dto.tsL1-R8](diffhunk://#diff-047f6c619b777744f54f345cc4e5066b4e4464d4210d7a0ee2c8f17e12cc99b1L1-R8), Fc6ccbc3L53, Fa27928cL12, Fa27928cL55, F68f64ebL1, F68f64ebL36, F68f64ebL75)

#### Updates to Data Repository:
* Replaced `getDefaultCostInputs` method with `getOverridableCostInputs` in `data.repository.ts`. This includes changes to the query builder to dynamically select implementation labor based on the activity type. [[1]](diffhunk://#diff-c610941a76971fae93d7d206fcbe042270836b452cabbd2d24eb844e96cfdc2eL1-R11) [[2]](diffhunk://#diff-c610941a76971fae93d7d206fcbe042270836b452cabbd2d24eb844e96cfdc2eL1-R11)6, Faabd43cL69, [[3]](diffhunk://#diff-c610941a76971fae93d7d206fcbe042270836b452cabbd2d24eb844e96cfdc2eL1-R11)26)

#### Changes in Service Layer:
* Updated `CustomProjectsService` to use the new `getOverridableCostInputs` method instead of the old `getDefaultCostInputs` method. (Fa9408dfL6, Fa9408dfL63)

#### Import and Enum Adjustments:
* Consolidated and cleaned up imports, particularly for `ACTIVITY` and `RESTORATION_ACTIVITY_SUBTYPE` enums across multiple files to ensure consistency. (F11a7946L3, Ff8e0900L1, [[1]](diffhunk://#diff-ad083bb6d1c2c0a5848677ec5c9ffc8329031525b705322557abe8e9e4c47ea5L1-R6) F6fd8acbL1, [[2]](diffhunk://#diff-3abb3f1b1db0d984ca3bf42d7ec38baebc2c114cc631c4fdcc93b5bf9004c7afL1-L9) Fb9031dbL9, Fb9031dbL27)

#### Contract and DTO Updates:
* Renamed `GetDefaultCostInputsDto` to `GetOverridableCostInputs` and updated all related references in DTOs and contracts. (Fe3b3447L1, F3806a84L5, F3806a84L32)

These changes are aimed at improving the flexibility and maintainability of the cost calculation logic by making cost inputs more dynamic and better structured.