### PR TITLE
temporal workaround to missing column data

### DIFF
--- a/api/src/modules/import/dtos/excel-projects.dto.ts
+++ b/api/src/modules/import/dtos/excel-projects.dto.ts
@@ -15,11 +15,12 @@ export type ExcelProjects = {
   activity_type: RESTORATION_ACTIVITY_SUBTYPE;
   project_size_ha: number;
   project_size_filter: string;
-  aAbatement_potential: number;
-  total_cost_NPV: number;
+  abatement_potential: number;
+  total_cost_npv: number;
   total_cost: number;
+  // TODO: This column has dissapeared from the excel sheet
   '$/tCO2e (NPV)': number;
-  '$/tCO2e': number;
+  cost_per_tco2e: number;
   initial_price_assumption: string;
   price_type: PROJECT_PRICE_TYPE;
 };

--- a/api/src/modules/import/services/entity.preprocessor.ts
+++ b/api/src/modules/import/services/entity.preprocessor.ts
@@ -1110,11 +1110,13 @@ export class EntityPreprocessor {
       project.restorationActivity = row.activity_type;
       project.projectSize = row.project_size_ha;
       project.projectSizeFilter = row.project_size_filter;
-      project.abatementPotential = row.aAbatement_potential;
-      project.totalCostNPV = row.total_cost_NPV;
+      project.abatementPotential = row.abatement_potential;
+      project.totalCostNPV = row.total_cost_npv;
       project.totalCost = row.total_cost;
-      project.costPerTCO2eNPV = row['$/tCO2e (NPV)'];
-      project.costPerTCO2e = row['$/tCO2e'];
+      // TODO: This has dissapeared from the excel file and it is required for filtering, setting a fake value for now
+      //project.costPerTCO2eNPV = row['$/tCO2e (NPV)'];
+      project.costPerTCO2eNPV = row.cost_per_tco2e;
+      project.costPerTCO2e = row.cost_per_tco2e;
       project.initialPriceAssumption = row.initial_price_assumption;
       project.priceType = row.price_type;
 


### PR DESCRIPTION
**IMPORTANT**: There has been several changes in the source datasheet:

We are missing price type, which is a filtering value and it is required: I have inserted values artificially in my local DB to keep working
'`$/tCO2e` has been renamed to cost_per_tco2e
`$/tCO2e (NPV)` is missing now

This pull request includes changes to the `ExcelProjects` type and the `EntityPreprocessor` class to correct property names and handle missing columns in the Excel sheet.

Changes to `ExcelProjects` type:

* Corrected property names from `aAbatement_potential` to `abatement_potential` and `total_cost_NPV` to `total_cost_npv`.
* Added a TODO comment for the missing column `$/tCO2e (NPV)`.
* Renamed property `/tCO2e'` to `cost_per_tco2e`.

Changes to `EntityPreprocessor` class:

* Updated property names to match the corrected names in `ExcelProjects`.
* Added a TODO comment and assigned a fake value for the missing column `$/tCO2e (NPV)`.