### PR TITLE
Fix/missing capex in npv cost details

### DIFF
--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -225,7 +225,6 @@ export class CostCalculator {
         capitalExpenditure: totalCapex,
         operationalExpenditure: totalOpex,
         totalCost: totalCapex + totalCapex,
-        operationExpenditure: totalOpex,
         feasibilityAnalysis: sum(
           Object.values(this.costPlans.feasibilityAnalysis),
         ),
@@ -298,7 +297,6 @@ export class CostCalculator {
           this.costPlans.implementationLabor,
           discountRate,
         ),
-        operationExpenditure: this.totalOpexNPV,
         monitoring: this.calculateNpv(this.costPlans.monitoring, discountRate),
         maintenance: this.calculateNpv(
           this.costPlans.maintenance,

--- a/api/src/modules/custom-projects/input-factory/custom-project.factory.ts
+++ b/api/src/modules/custom-projects/input-factory/custom-project.factory.ts
@@ -5,11 +5,7 @@ import { AdditionalBaseData } from '@api/modules/calculations/data.repository';
 
 import { CreateCustomProjectDto } from '@api/modules/custom-projects/dto/create-custom-project-dto';
 import { ConservationProjectInput } from '@api/modules/custom-projects/input-factory/conservation-project.input';
-import {
-  ModelAssumptionsForCalculations,
-  NonOverridableModelAssumptions,
-} from '@api/modules/calculations/assumptions.repository';
-import { BaseDataView } from '@shared/entities/base-data.view';
+import { NonOverridableModelAssumptions } from '@api/modules/calculations/assumptions.repository';
 import { CostOutput } from '@api/modules/calculations/calculation.engine';
 import { ProjectInput } from '@api/modules/calculations/cost.calculator';
 import { CustomProject } from '@shared/entities/custom-project.entity';

--- a/shared/dtos/custom-projects/custom-project-output.dto.ts
+++ b/shared/dtos/custom-projects/custom-project-output.dto.ts
@@ -32,7 +32,6 @@ export type CustomProjectCostDetails = {
   establishingCarbonRights: number;
   validation: number;
   implementationLabor: number;
-  operationExpenditure: number;
   monitoring: number;
   maintenance: number;
   communityBenefitSharingFund: number;

--- a/shared/entities/projects.entity.ts
+++ b/shared/entities/projects.entity.ts
@@ -10,6 +10,7 @@ import {
 import { Country } from "@shared/entities/country.entity";
 import { ECOSYSTEM } from "./ecosystem.enum";
 import { ACTIVITY, RESTORATION_ACTIVITY_SUBTYPE } from "./activity.enum";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
 
 export enum PROJECT_SIZE_FILTER {
   SMALL = "Small",
@@ -98,4 +99,12 @@ export class Project extends BaseEntity {
     nullable: true,
   })
   priceType: PROJECT_PRICE_TYPE;
+
+  @Column({
+    type: "enum",
+    enum: PROJECT_SCORE,
+    default: PROJECT_SCORE.MEDIUM,
+    name: "score_card_rating",
+  })
+  scoreCardRating: PROJECT_SCORE;
 }


### PR DESCRIPTION
This pull request includes several changes focused on the `CostCalculator` class, import optimizations, and modifications to the `Project` entity. The most important changes are summarized below:

### Changes to `CostCalculator` class:

* Removed redundant `operationExpenditure` property from the `CostCalculator` class to avoid duplication and potential confusion. (`api/src/modules/calculations/cost.calculator.ts`) [[1]](diffhunk://#diff-f3a786faa816de52227b70d447bbed13537c00886ffc27518b616149b4a2e4d7L228) [[2]](diffhunk://#diff-f3a786faa816de52227b70d447bbed13537c00886ffc27518b616149b4a2e4d7L301)

### Import optimizations:

* Cleaned up imports in the `custom-project.factory.ts` file by removing unused imports and consolidating necessary ones. (`api/src/modules/custom-projects/input-factory/custom-project.factory.ts`)

### Changes to `Project` entity:

* Added a new `scoreCardRating` column to the `Project` entity with a default value of `PROJECT_SCORE.MEDIUM`. This column uses the `PROJECT_SCORE` enum. (`shared/entities/projects.entity.ts`)
* Included the `PROJECT_SCORE` import in the `projects.entity.ts` file to support the new `scoreCardRating` column. (`shared/entities/projects.entity.ts`)

### Changes to DTOs:

* Removed the `operationExpenditure` field from the `CustomProjectCostDetails` type to align with changes in the `CostCalculator` class. (`shared/dtos/custom-projects/custom-project-output.dto.ts`)