### PR TITLE
Fix/missing cost keys yearly breakdown

### DIFF
--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -397,6 +397,8 @@ export class CostCalculator {
       totalCostPlan,
       estimatedRevenuePlan,
       creditsIssuedPlan,
+      cumulativeNetIncomePlan,
+      cumulativeNetIncomeCapexOpex,
     });
 
     const yearlyBreakdown: YearlyBreakdown[] = [];

--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -399,6 +399,8 @@ export class CostCalculator {
       creditsIssuedPlan,
       cumulativeNetIncomePlan,
       cumulativeNetIncomeCapexOpex,
+      annualNetCashFlow,
+      annualNetIncome,
     });
 
     const yearlyBreakdown: YearlyBreakdown[] = [];

--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -392,8 +392,12 @@ export class CostCalculator {
       }
     }
 
-    const yearNormalizedCostPlans: CostPlans =
-      this.normalizeCostPlan(costPlans);
+    const yearNormalizedCostPlans: CostPlans = this.normalizeCostPlan({
+      ...costPlans,
+      totalCostPlan,
+      estimatedRevenuePlan,
+      creditsIssuedPlan,
+    });
 
     const yearlyBreakdown: YearlyBreakdown[] = [];
     for (const costName in yearNormalizedCostPlans) {


### PR DESCRIPTION
This pull request includes changes to the `CostCalculator` class in the `cost.calculator.ts` file to enhance the normalization of cost plans by including additional financial metrics. The most important change is the modification of the `normalizeCostPlan` method call to include a broader set of cost-related data.

Enhancements to cost plan normalization:

* [`api/src/modules/calculations/cost.calculator.ts`](diffhunk://#diff-f3a786faa816de52227b70d447bbed13537c00886ffc27518b616149b4a2e4d7L395-R404): Modified the `normalizeCostPlan` method call to include `totalCostPlan`, `estimatedRevenuePlan`, `creditsIssuedPlan`, `cumulativeNetIncomePlan`, `cumulativeNetIncomeCapexOpex`, `annualNetCashFlow`, and `annualNetIncome` in the `CostCalculator` class.