### PR TITLE
fix(api): The project map now applies priceType and projectSizeFilter…

### DIFF
--- a/api/src/modules/projects/projects-map.repository.ts
+++ b/api/src/modules/projects/projects-map.repository.ts
@@ -83,6 +83,22 @@ export class ProjectsMapRepository extends Repository<Project> {
     const { costRange, abatementPotentialRange, costRangeSelector } =
       otherFilters;
 
+    if (projectSizeFilter) {
+      for (const projectSize of projectSizeFilter) {
+        queryBuilder.andWhere('p.project_size_filter = :projectSizeFilter', {
+          projectSizeFilter: projectSize,
+        });
+      }
+    }
+
+    if (priceType) {
+      for (const type of priceType) {
+        queryBuilder.andWhere('p.price_type = :priceType', {
+          priceType: type,
+        });
+      }
+    }
+
     if (costRangeSelector === 'npv') {
       queryBuilder.addSelect('SUM(p.total_cost_npv)', 'total_cost');
     } else {


### PR DESCRIPTION
… filters
This pull request introduces new filtering capabilities to the `ProjectsMapRepository` and adds corresponding tests to ensure these filters work as expected. The most important changes include the addition of `projectSizeFilter` and `priceType` filters in the repository, and the creation of integration tests to verify these filters.

### Repository Enhancements:

* Added `projectSizeFilter` to the `ProjectsMapRepository` to filter projects by size.
* Added `priceType` to the `ProjectsMapRepository` to filter projects by price type.

### Testing Enhancements:

* Imported `PROJECT_PRICE_TYPE` and `PROJECT_SIZE_FILTER` in `project-map.spec.ts` to support new tests.
* Added integration test to verify that projects can be filtered by `priceType`.
* Added integration test to verify that projects can be filtered by `projectSizeFilter`.