### PR TITLE
bug(backoffice): The logout handler should also remove the next-auth.session-token not only in dev but in target environments

### DIFF
--- a/backoffice/providers/auth.provider.ts
+++ b/backoffice/providers/auth.provider.ts
@@ -38,6 +38,7 @@ export class AuthProvider extends BaseAuthProvider {
     res.setHeader('Set-Cookie', [
       `backoffice=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`,
       `next-auth.session-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`,
+      `__Secure-next-auth.session-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`,
     ]);
   }
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `backoffice/providers/auth.provider.ts` file. The change ensures that the `__Secure-next-auth.session-token` cookie is properly cleared when logging out.

Changes to cookie handling:

* [`backoffice/providers/auth.provider.ts`](diffhunk://#diff-5e6b825379c79f89b1b8babd0ce0abd59ad840e1376762d6bc8a99877904a265R41): Added the `__Secure-next-auth.session-token` cookie to the list of cookies being cleared during logout.