### PR TITLE
chore(cd): Adjust deployment rules for target environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ on:
       - 'package.json'
 
 jobs:
-
   set_environment_name:
     name: Set Environment
     runs-on: ubuntu-latest
@@ -26,9 +25,38 @@ jobs:
       - id: set_env
         run: echo "env_name=${{ github.ref_name == 'main' && 'production' || github.ref_name }}" >> $GITHUB_OUTPUT
 
+  trigger_build:
+    runs-on: ubuntu-latest
+    outputs:
+      build_client: ${{ steps.changes.outputs.client == 'true' || github.ref_name == 'staging' || github.ref_name == 'main' }}
+      build_api: ${{ steps.changes.outputs.api == 'true' || github.ref_name == 'staging' || github.ref_name == 'main' }}
+      build_backoffice: ${{ steps.changes.outputs.backoffice == 'true' || github.ref_name == 'staging' || github.ref_name == 'main' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect changes in client and API paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            client:
+              - '.github/workflows/**'
+              - 'shared/**'
+              - 'client/**'
+            api:
+              - '.github/workflows/**'
+              - 'shared/**'
+              - 'api/**'
+            backoffice:
+              - '.github/workflows/**'
+              - 'shared/**'
+              - 'backoffice/**'
+
 
   build_client:
-    needs: [ set_environment_name ]
+    needs: [ set_environment, trigger_build ]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.trigger_build.outputs.build_client == 'true' }}
     environment:
       name: ${{ needs.set_environment_name.outputs.env_name }}
     runs-on: ubuntu-latest
@@ -36,17 +64,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: client-changes
-        with:
-          filters: |
-            client:
-              - 'client/**'
-              - '.github/workflows/**'
-            shared:
-              - 'shared/**'
-
 
       - name: Configure AWS credentials
         if: ${{ github.event_name == 'workflow_dispatch' || steps.client-changes.outputs.client == 'true' }}
@@ -86,7 +103,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ secrets.CLIENT_REPOSITORY_NAME }}:${{ needs.set_environment_name.outputs.env_name }}
 
   build_api:
-    needs: [ set_environment_name ]
+    needs: [ set_environment, trigger_build ]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.trigger_build.outputs.build_api == 'true' }}
     environment:
       name: ${{ needs.set_environment_name.outputs.env_name }}
     runs-on: ubuntu-latest
@@ -94,16 +112,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: api-changes
-        with:
-          filters: |
-            api:
-              - 'api/**'
-              - '.github/workflows/**'
-            shared:
-              - 'shared/**'
 
       - name: Configure AWS credentials
         if: ${{ github.event_name == 'workflow_dispatch' || steps.api-changes.outputs.api == 'true' }}
@@ -158,7 +166,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ secrets.API_REPOSITORY_NAME }}:${{ needs.set_environment_name.outputs.env_name }}
 
   build_backoffice:
-    needs: [ set_environment_name ]
+    needs: [ set_environment, trigger_build ]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.trigger_build.outputs.build_backoffice == 'true' }}
     environment:
       name: ${{ needs.set_environment_name.outputs.env_name }}
     runs-on: ubuntu-latest
@@ -166,16 +175,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: backoffice-changes
-        with:
-          filters: |
-            backoffice:
-              - 'backoffice/**'
-              - '.github/workflows/**'
-            shared:
-              - 'shared/**'
 
       - name: Configure AWS credentials
         if: ${{ github.event_name == 'workflow_dispatch' || steps.backoffice-changes.outputs.backoffice == 'true' }}


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/deploy.yml` file to enhance the deployment workflow. The key updates involve restructuring job dependencies, refining conditional logic for triggering builds, and consolidating path filters.

### Workflow Enhancements:

* **Job Dependencies and Conditional Logic:**
  - Introduced a new `trigger_build` job to determine if client, API, or backoffice builds are necessary based on changes or branch conditions.
  - Updated `build_client`, `build_api`, and `build_backoffice` jobs to depend on both `set_environment` and `trigger_build` jobs and to include conditional execution based on the `trigger_build` outputs. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L89-R107) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L161-R170)

* **Consolidation of Path Filters:**
  - Merged individual path filters for client, API, and backoffice changes into a single `Detect changes in client and API paths` step within the `trigger_build` job. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L29-R67) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L170-L179)

These changes aim to streamline the workflow, reduce redundancy, and ensure that builds are only triggered when necessary, improving overall efficiency.