### PR TITLE
chore(cd): Adjust deployment rules for target environments (2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
 
   build_client:
-    needs: [ set_environment, trigger_build ]
+    needs: [ set_environment_name, trigger_build ]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.trigger_build.outputs.build_client == 'true' }}
     environment:
       name: ${{ needs.set_environment_name.outputs.env_name }}
@@ -103,7 +103,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ secrets.CLIENT_REPOSITORY_NAME }}:${{ needs.set_environment_name.outputs.env_name }}
 
   build_api:
-    needs: [ set_environment, trigger_build ]
+    needs: [ set_environment_name, trigger_build ]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.trigger_build.outputs.build_api == 'true' }}
     environment:
       name: ${{ needs.set_environment_name.outputs.env_name }}
@@ -166,7 +166,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ secrets.API_REPOSITORY_NAME }}:${{ needs.set_environment_name.outputs.env_name }}
 
   build_backoffice:
-    needs: [ set_environment, trigger_build ]
+    needs: [ set_environment_name, trigger_build ]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.trigger_build.outputs.build_backoffice == 'true' }}
     environment:
       name: ${{ needs.set_environment_name.outputs.env_name }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/deploy.yml` file to update the dependencies for various jobs. The most important changes involve modifying the `needs` dependencies from `set_environment` to `set_environment_name` for the `build_client`, `build_api`, and `build_backoffice` jobs.

Updates to job dependencies:

* Changed `needs` dependency from `set_environment` to `set_environment_name` for the `build_client` job. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL58-R58](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L58-R58))
* Changed `needs` dependency from `set_environment` to `set_environment_name` for the `build_api` job. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL106-R106](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L106-R106))
* Changed `needs` dependency from `set_environment` to `set_environment_name` for the `build_backoffice` job. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL169-R169](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L169-R169))