### PR TITLE
Feat search projects with maximums

### DIFF
--- a/api/src/modules/projects/projects.controller.ts
+++ b/api/src/modules/projects/projects.controller.ts
@@ -24,7 +24,9 @@ export class ProjectsController {
   @TsRestHandler(projectsContract.getProjects)
   async getProjects(): ControllerResponse {
     return tsRestHandler(projectsContract.getProjects, async ({ query }) => {
-      const data = await this.projectsService.findAllPaginated(query);
+      const data = query.withMaximums
+        ? await this.projectsService.findAllProjectsWithMaximums(query)
+        : await this.projectsService.findAllPaginated(query);
       return { body: data, status: HttpStatus.OK };
     });
   }

--- a/api/test/integration/custom-projects/custom-projects-read.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-read.spec.ts
@@ -116,5 +116,38 @@ describe('Read Custom projects', () => {
         responseData.find((cp: CustomProject) => cp.id === customProject2.id),
       ).toBeDefined();
     });
+
+    test('An authenticated user should be able to retrieve its custom projects filtering by partialProjectName', async () => {
+      // Given
+      const { createCustomProject } = testManager.mocks();
+      const [customProject1, customProject2] = await Promise.all([
+        createCustomProject({
+          id: '2d8fdf38-3295-4970-b194-af503a2a6031',
+          projectName: 'Should not be found',
+          user: { id: user.id } as User,
+        }),
+        createCustomProject({
+          id: '2d8fdf38-3295-4970-b194-af503a2a6039',
+          projectName: 'Seagrass',
+          user: { id: user.id } as User,
+        }),
+      ]);
+
+      // When
+      const response = await testManager
+        .request()
+        .get(customProjectContract.getCustomProjects.path)
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .query({ partialProjectName: 'Sea' })
+        .send();
+
+      // Then
+      expect(response.status).toBe(200);
+      const responseData = response.body.data;
+      expect(responseData.length).toBe(1);
+      expect(
+        responseData.find((cp: CustomProject) => cp.id === customProject2.id),
+      ).toBeDefined();
+    });
   });
 });

--- a/api/test/integration/projects/projects.spec.ts
+++ b/api/test/integration/projects/projects.spec.ts
@@ -324,6 +324,38 @@ describe('Projects', () => {
     });
   });
 
+  test('Should return a list of filtered projects with maximum values', async () => {
+    await testManager.mocks().createProject({
+      id: 'e934e9fe-a79c-40a5-8254-8817851764ad',
+      projectName: 'PROJ_ABC',
+      totalCost: 100,
+      totalCostNPV: 50,
+      abatementPotential: 10,
+    });
+    await testManager.mocks().createProject({
+      id: 'e934e9fe-a79c-40a5-8254-8817851764ae',
+      projectName: 'PROJ_DEF',
+      totalCost: 200,
+      totalCostNPV: 100,
+      abatementPotential: 20,
+    });
+
+    const response = await testManager
+      .request()
+      .get(projectsContract.getProjects.path)
+      .query({
+        withMaximums: true,
+        partialProjectName: 'PROJ',
+      });
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.data).toHaveLength(2);
+    expect(response.body.maximums).toEqual({
+      maxAbatementPotential: 20,
+      maxTotalCost: 300,
+    });
+  });
+
   describe('Filters for Projects', () => {
     test('Should get a list of countries there are projects in', async () => {
       const fiveCountriesWithNoGeometry = countriesInDb

--- a/shared/contracts/custom-projects.contract.ts
+++ b/shared/contracts/custom-projects.contract.ts
@@ -18,8 +18,13 @@ import { generateEntityQuerySchema } from "@shared/schemas/query-param.schema";
 import { ActivityTypesDefaults } from "@shared/dtos/custom-projects/activity-types-defaults";
 import { GetActivityTypesDefaultsSchema } from "@shared/schemas/custom-projects/activity-types-defaults.schema";
 
-export const customProjecsQuerySchema =
-  generateEntityQuerySchema(CustomProject);
+export const customProjecsQuerySchema = generateEntityQuerySchema(
+  CustomProject,
+).merge(
+  z.object({
+    partialProjectName: z.string().optional(),
+  }),
+);
 
 const contract = initContract();
 export const customProjectContract = contract.router({

--- a/shared/contracts/projects.contract.ts
+++ b/shared/contracts/projects.contract.ts
@@ -11,32 +11,36 @@ import { ProjectMap } from "@shared/dtos/projects/projects-map.dto";
 import { generateEntityQuerySchema } from "@shared/schemas/query-param.schema";
 import { BaseEntity } from "typeorm";
 import { ProjectScorecardView } from "@shared/entities/project-scorecard.view";
+import { PaginatedProjectsWithMaximums } from "@shared/dtos/projects/projects.dto";
 
 const contract = initContract();
 
 export type ProjectType = Omit<Project, keyof BaseEntity>;
 export type ProjectScorecardType = Omit<ProjectScorecard, keyof BaseEntity>;
 
-export const otherFilters = z.object({
+export const otherParams = z.object({
   costRange: z.coerce.number().array().optional(),
   abatementPotentialRange: z.coerce.number().array().optional(),
   costRangeSelector: z.nativeEnum(COST_TYPE_SELECTOR).optional(),
   partialProjectName: z.string().optional(),
+  withMaximums: z.coerce.boolean().optional(),
 });
 export const projectsQuerySchema = generateEntityQuerySchema(Project);
 export const projectScorecardQuerySchema =
   generateEntityQuerySchema(ProjectScorecard);
 
-export const getProjectsQuerySchema = projectsQuerySchema.merge(otherFilters);
+export const getProjectsQuerySchema = projectsQuerySchema.merge(otherParams);
 export const getProjectScorecardQuerySchema =
-  projectScorecardQuerySchema.merge(otherFilters);
+  projectScorecardQuerySchema.merge(otherParams);
 
 export const projectsContract = contract.router({
   getProjects: {
     method: "GET",
     path: "/projects",
     responses: {
-      200: contract.type<ApiPaginationResponse<Project>>(),
+      200: contract.type<
+        ApiPaginationResponse<Project> | PaginatedProjectsWithMaximums
+      >(),
     },
     query: getProjectsQuerySchema,
   },

--- a/shared/dtos/projects/projects.dto.ts
+++ b/shared/dtos/projects/projects.dto.ts
@@ -1,0 +1,11 @@
+import { PaginationMeta } from "@shared/dtos/global/api-response.dto";
+import { Project } from "@shared/entities/projects.entity";
+
+export class PaginatedProjectsWithMaximums {
+  metadata: PaginationMeta;
+  data: Partial<Project>[];
+  maximums: {
+    maxAbatementPotential: number;
+    maxCost: number;
+  };
+}


### PR DESCRIPTION
This pull request introduces several enhancements to the `CustomProjectsService` and `ProjectsService` in the API, including new filtering capabilities and the ability to retrieve maximum values for certain project attributes. Additionally, it updates related contracts and tests to support these changes.

### Enhancements to Custom Projects:

* Added a new type `CustomProjectFetchSpecificacion` and schema `customProjecsQuerySchema` to support filtering by `partialProjectName` in `CustomProjectsService`. [[1]](diffhunk://#diff-a450b42f83aa743e906c235e1dbcc649854328c6951985e9bcaf6a40b6029eacL23-R28) [[2]](diffhunk://#diff-a450b42f83aa743e906c235e1dbcc649854328c6951985e9bcaf6a40b6029eacL124-R129)
* Implemented filtering logic in `extendFindAllQuery` method to allow querying by partial project name.

### Enhancements to Projects:

* Introduced `findAllProjectsWithMaximums` method in `ProjectsService` to fetch projects along with maximum values for `abatementPotential` and `totalCost`. [[1]](diffhunk://#diff-f4e9fe665933514d01aa02820eac87bc916dc468d4f5cb3e4ad50901c441417aR20-R62) [[2]](diffhunk://#diff-f4e9fe665933514d01aa02820eac87bc916dc468d4f5cb3e4ad50901c441417aL60-R100)
* Updated `ProjectsController` to handle the new query parameter `withMaximums` and call the appropriate service method.

### Contract and DTO Updates:

* Modified `projectsQuerySchema` and `customProjecsQuerySchema` to include new filtering parameters. [[1]](diffhunk://#diff-80698112c9f6678b19f76e41e7ca080b541225446ff06c624faec7c19c144578L21-R27) [[2]](diffhunk://#diff-c9b97aa6f1ae834706856581888b50f98001fe75b0bb3ad602eefb5960242ce8R14-R43)
* Added a new DTO `PaginatedProjectsWithMaximums` to structure the response containing maximum values.

### Test Enhancements:

* Added integration tests for filtering custom projects by `partialProjectName` and for retrieving projects with maximum values. [[1]](diffhunk://#diff-3bbc03f59e46249f00fa6fa5aa4b14c60ce9362b602b38438d62eeabdd14a407R119-R151) [[2]](diffhunk://#diff-8d9e3a7c7767f19e943245dbb202976e0fd70dcf9f29cd06449eba72dc7be692R327-R358)