### PR TITLE
[TBCCT-198] hides "share information" section in user profile

### DIFF
--- a/client/src/containers/profile/index.tsx
+++ b/client/src/containers/profile/index.tsx
@@ -8,8 +8,8 @@ import { useSetAtom } from "jotai";
 
 import CustomProjects from "@/containers/profile/custom-projects";
 import DeleteAccount from "@/containers/profile/delete-account";
-import FileUpload, { TEMPLATE_FILES } from "@/containers/profile/file-upload";
-import FileUploadDescription from "@/containers/profile/file-upload/description";
+// import FileUpload, { TEMPLATE_FILES } from "@/containers/profile/file-upload";
+// import FileUploadDescription from "@/containers/profile/file-upload/description";
 import ProfileSection from "@/containers/profile/profile-section";
 import ProfileSidebar from "@/containers/profile/profile-sidebar";
 import { intersectingAtom } from "@/containers/profile/store";
@@ -39,12 +39,12 @@ const sections = [
     ),
     Component: CustomProjects,
   },
-  {
-    id: "share-information",
-    title: "Share information",
-    description: <FileUploadDescription files={TEMPLATE_FILES} />,
-    Component: FileUpload,
-  },
+  // {
+  //   id: "share-information",
+  //   title: "Share information",
+  //   description: <FileUploadDescription files={TEMPLATE_FILES} />,
+  //   Component: FileUpload,
+  // },
   {
     id: "delete-account",
     title: "Delete account",


### PR DESCRIPTION
This pull request includes changes to the `client/src/containers/profile/index.tsx` file to comment out the `FileUpload` and `FileUploadDescription` components and their associated import statements. The most important changes are:

Codebase simplification:

* Commented out the import statements for `FileUpload` and `FileUploadDescription` to prevent their usage in the profile container.
* Commented out the `share-information` section that used `FileUpload` and `FileUploadDescription` components in the profile container.