### PR TITLE
feat: Add capex and opex columns to the project entity and truncate d…

### DIFF
--- a/api/src/modules/import/dtos/excel-projects.dto.ts
+++ b/api/src/modules/import/dtos/excel-projects.dto.ts
@@ -16,6 +16,10 @@ export type ExcelProjects = {
   project_size_ha: number;
   project_size_filter: string;
   abatement_potential: number;
+  capex_npv: number;
+  capex: number;
+  opex_npv: number;
+  opex: number;
   total_cost_npv: number;
   total_cost: number;
   cost_per_tco2e_npv: number;

--- a/api/src/modules/import/import.repostiory.ts
+++ b/api/src/modules/import/import.repostiory.ts
@@ -68,7 +68,42 @@ export class ImportRepository {
     baseIncrease: BaseIncrease[];
     modelAssumptions: ModelAssumptions[];
   }) {
-    return this.dataSource.transaction(async (manager) => {
+    return this.dataSource.transaction('READ COMMITTED', async (manager) => {
+      // DATA WIPE STARTS
+      await manager.clear(Project);
+      await manager.clear(ProjectSize);
+      await manager.clear(FeasibilityAnalysis);
+      await manager.clear(ConservationPlanningAndAdmin);
+      await manager.clear(DataCollectionAndFieldCosts);
+      await manager.clear(CommunityRepresentation);
+      await manager.clear(BlueCarbonProjectPlanning);
+      await manager.clear(CarbonRights);
+      await manager.clear(FinancingCost);
+      await manager.clear(ValidationCost);
+      await manager.clear(MonitoringCost);
+      await manager.clear(Maintenance);
+      await manager.clear(CommunityBenefitSharingFund);
+      await manager.clear(BaselineReassessment);
+      await manager.clear(MRV);
+      await manager.clear(LongTermProjectOperating);
+      await manager.clear(CarbonStandardFees);
+      await manager.clear(CommunityCashFlow);
+      await manager.clear(ImplementationLaborCost);
+
+      // Carbon inputs ingestion
+      await manager.clear(EcosystemExtent);
+      await manager.clear(EcosystemLoss);
+      await manager.clear(RestorableLand);
+      await manager.clear(SequestrationRate);
+      await manager.clear(EmissionFactors);
+
+      // Other tables ingestion
+      await manager.clear(BaseSize);
+      await manager.clear(BaseIncrease);
+      await manager.clear(ModelAssumptions);
+      // DATA WIPE ENDS
+
+      // CREATION STARTS
       await manager.save(importData.projects);
 
       // Cost inputs ingestion
@@ -102,6 +137,7 @@ export class ImportRepository {
       await manager.save(importData.baseSize);
       await manager.save(importData.baseIncrease);
       await manager.save(importData.modelAssumptions);
+      // CREATION ENDS
     });
   }
 }

--- a/api/src/modules/import/services/entity.preprocessor.ts
+++ b/api/src/modules/import/services/entity.preprocessor.ts
@@ -1118,6 +1118,10 @@ export class EntityPreprocessor {
       project.projectSize = row.project_size_ha;
       project.projectSizeFilter = row.project_size_filter;
       project.abatementPotential = row.abatement_potential;
+      project.opexNpv = row.opex_npv;
+      project.opex = row.opex;
+      project.capexNpv = row.capex_npv;
+      project.capex = row.capex;
       project.totalCostNPV = row.total_cost_npv;
       project.totalCost = row.total_cost;
       // TODO: This has dissapeared from the excel file and it is required for filtering, setting a fake value for now

--- a/shared/entities/projects.entity.ts
+++ b/shared/entities/projects.entity.ts
@@ -72,6 +72,18 @@ export class Project extends BaseEntity {
   @Column({ name: "abatement_potential", type: "decimal", nullable: true })
   abatementPotential: number;
 
+  @Column({ name: "capex_npv", type: "decimal", nullable: true })
+  capexNpv: number;
+
+  @Column({ name: "capex", type: "decimal", nullable: true })
+  capex: number;
+
+  @Column({ name: "opex_npv", type: "decimal", nullable: true })
+  opexNpv: number;
+
+  @Column({ name: "opex", type: "decimal", nullable: true })
+  opex: number;
+
   @Column({ name: "total_cost_npv", type: "decimal", nullable: true })
   totalCostNPV: number;
 

--- a/shared/lib/entity-mocks.ts
+++ b/shared/lib/entity-mocks.ts
@@ -55,6 +55,10 @@ export const createProject = async (
     totalCost: 100,
     costPerTCO2eNPV: 100,
     costPerTCO2e: 100,
+    capexNpv: 100,
+    capex: 50,
+    opexNpv: 100,
+    opex: 50,
     initialPriceAssumption: "$100",
     priceType: PROJECT_PRICE_TYPE.MARKET_PRICE,
   };


### PR DESCRIPTION
This pull request introduces several changes to the import module and project entities to include new financial metrics and handle data ingestion more comprehensively. The most important changes include adding new fields to the `ExcelProjects` DTO, updating the `ImportRepository` to clear and save additional data, and modifying the `Project` entity and related files to accommodate new financial metrics.

### Enhancements to Data Models:

* [`api/src/modules/import/dtos/excel-projects.dto.ts`](diffhunk://#diff-ad083bb6d1c2c0a5848677ec5c9ffc8329031525b705322557abe8e9e4c47ea5R19-R22): Added new financial metrics fields `capex_npv`, `capex`, `opex_npv`, and `opex` to the `ExcelProjects` type.
* [`shared/entities/projects.entity.ts`](diffhunk://#diff-28ead360acbcb3bdd782ac3976d9bebeb229ea77d47d51182a309fa5dd7bc296R75-R86): Added new columns `capexNpv`, `capex`, `opexNpv`, and `opex` to the `Project` entity to store the new financial metrics.

### Updates to Data Processing:

* [`api/src/modules/import/import.repository.ts`](diffhunk://#diff-a7f7a9963ea5c5c2c3ea37d5ac6e435be607b406814aa09d2811ff7163019358L71-R106): Updated the `ImportRepository` class to clear multiple tables before saving new data during the import process. This ensures a clean state before data ingestion. [[1]](diffhunk://#diff-a7f7a9963ea5c5c2c3ea37d5ac6e435be607b406814aa09d2811ff7163019358L71-R106) [[2]](diffhunk://#diff-a7f7a9963ea5c5c2c3ea37d5ac6e435be607b406814aa09d2811ff7163019358R140)
* [`api/src/modules/import/services/entity.preprocessor.ts`](diffhunk://#diff-7a719450786dd500376e93852a28b7672b2d35806af1486e45ab382d633f0dcdR1121-R1124): Modified the `EntityPreprocessor` class to set the new financial metrics fields (`capexNpv`, `capex`, `opexNpv`, and `opex`) during the preprocessing of project data.

### Mock Data Adjustments:

* [`shared/lib/entity-mocks.ts`](diffhunk://#diff-eb7e19b4c920dacc9a6f2bc0a84e3c60ad251315bbb443e48a3609a2ec729ff0R58-R61): Updated the `createProject` function to include default values for the new financial metrics fields (`capexNpv`, `capex`, `opexNpv`, and `opex`).