### PR TITLE
Added useTablePaginationReset hook for consistent search behavior

### DIFF
--- a/client/src/containers/my-projects/index.tsx
+++ b/client/src/containers/my-projects/index.tsx
@@ -23,6 +23,8 @@ import { cn, getAuthHeader } from "@/lib/utils";
 
 import { useMyProjectsFilters } from "@/app/my-projects/url-store";
 
+import { useTablePaginationReset } from "@/hooks/use-table-pagination-reset";
+
 import Search from "@/components/ui/search";
 import { useSidebar } from "@/components/ui/sidebar";
 import {
@@ -64,6 +66,8 @@ export default function MyProjectsView() {
     sorting,
     pagination,
   }).queryKey;
+
+  useTablePaginationReset(filters.keyword, setPagination);
 
   const { data } = client.customProjects.getCustomProjects.useQuery(
     queryKey,

--- a/client/src/containers/overview/table/view/key-costs/index.tsx
+++ b/client/src/containers/overview/table/view/key-costs/index.tsx
@@ -20,6 +20,8 @@ import { cn } from "@/lib/utils";
 
 import { useGlobalFilters, useTableView } from "@/app/(overview)/url-store";
 
+import { useTablePaginationReset } from "@/hooks/use-table-pagination-reset";
+
 import {
   filtersToQueryParams,
   NO_DATA,
@@ -51,6 +53,7 @@ export function KeyCostsTable() {
     pageIndex: 0,
     pageSize: Number.parseInt(PAGINATION_SIZE_OPTIONS[0]),
   });
+  useTablePaginationReset(filters.keyword, setPagination);
 
   const queryKey = queryKeys.tables.all(tableView, projectsQuerySchema, {
     ...filters,

--- a/client/src/containers/overview/table/view/overview/index.tsx
+++ b/client/src/containers/overview/table/view/overview/index.tsx
@@ -23,6 +23,8 @@ import { cn } from "@/lib/utils";
 import { projectDetailsAtom } from "@/app/(overview)/store";
 import { useGlobalFilters, useTableView } from "@/app/(overview)/url-store";
 
+import { useTablePaginationReset } from "@/hooks/use-table-pagination-reset";
+
 import ProjectDetails from "@/containers/overview/project-details";
 import {
   filtersToQueryParams,
@@ -55,10 +57,12 @@ export function OverviewTable() {
       desc: true,
     },
   ]);
+
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: Number.parseInt(PAGINATION_SIZE_OPTIONS[0]),
   });
+  useTablePaginationReset(filters.keyword, setPagination);
 
   const queryKey = queryKeys.tables.all(tableView, projectsQuerySchema, {
     ...filters,

--- a/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
+++ b/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
@@ -22,6 +22,8 @@ import { cn } from "@/lib/utils";
 import { projectDetailsAtom } from "@/app/(overview)/store";
 import { useGlobalFilters, useTableView } from "@/app/(overview)/url-store";
 
+import { useTablePaginationReset } from "@/hooks/use-table-pagination-reset";
+
 import ProjectDetails from "@/containers/overview/project-details";
 import {
   filtersToQueryParams,
@@ -62,6 +64,7 @@ export function ScoredCardPrioritizationTable() {
     sorting,
     pagination,
   }).queryKey;
+  useTablePaginationReset(filters.keyword, setPagination);
 
   const { data, isSuccess } = client.projects.getProjectsScorecard.useQuery(
     queryKey,

--- a/client/src/hooks/use-table-pagination-reset.ts
+++ b/client/src/hooks/use-table-pagination-reset.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+import { PaginationState } from "@tanstack/react-table";
+
+export function useTablePaginationReset(
+  keyword: string | undefined,
+  setPagination: (updater: (prev: PaginationState) => PaginationState) => void,
+) {
+  useEffect(() => {
+    setPagination((prev) => ({
+      ...prev,
+      pageIndex: 0,
+    }));
+  }, [keyword, setPagination]);
+}


### PR DESCRIPTION
## Added useTablePaginationReset hook for consistent search behavior

- Create reusable hook to reset pagination on search
- Implement hook across all table views (Overview, KeyCosts, ScorecardPrioritization)
- Ensure users start from page 1 when performing new searches

[TBCCT-205](https://vizzuality.atlassian.net/browse/TBCCT-205)

[TBCCT-205]: https://vizzuality.atlassian.net/browse/TBCCT-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ