### PR TITLE
[TBCCT-201] slider: displays current value while dragging the thumb

### DIFF
--- a/client/src/components/ui/slider.tsx
+++ b/client/src/components/ui/slider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useState } from "react";
 
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
@@ -58,6 +59,10 @@ const RangeSlider = React.forwardRef<
     format?: (v: number) => number | string;
   }
 >(({ className, format = (v: number) => v, ...props }, ref) => {
+  const [isDragging, setIsDragging] = useState({
+    left: false,
+    right: false,
+  });
   const [values, setValues] = React.useState([
     props.defaultValue?.[0] || 0,
     props.defaultValue?.[1] || 0,
@@ -79,18 +84,32 @@ const RangeSlider = React.forwardRef<
       <SliderPrimitive.Track className={SLIDER_TRACK_STYLES}>
         <SliderPrimitive.Range className="absolute h-full bg-primary" />
       </SliderPrimitive.Track>
-      <Tooltip>
+      <Tooltip {...(isDragging["left"] && { open: true })}>
         <TooltipTrigger asChild>
-          <Thumb />
+          <Thumb
+            onPointerDown={() => {
+              setIsDragging((prevState) => ({ ...prevState, left: true }));
+            }}
+            onPointerUp={() => {
+              setIsDragging((prevState) => ({ ...prevState, left: false }));
+            }}
+          />
         </TooltipTrigger>
         <TooltipContent side="top" align="center">
           {format(values[0])}
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip>
+      <Tooltip {...(isDragging["right"] && { open: true })}>
         <TooltipTrigger asChild>
-          <Thumb />
+          <Thumb
+            onPointerDown={() => {
+              setIsDragging((prevState) => ({ ...prevState, right: true }));
+            }}
+            onPointerUp={() => {
+              setIsDragging((prevState) => ({ ...prevState, right: false }));
+            }}
+          />
         </TooltipTrigger>
         <TooltipContent side="top" align="center">
           {format(values[1])}


### PR DESCRIPTION
This pull request includes changes to the `RangeSlider` component in the `client/src/components/ui/slider.tsx` file to enhance its functionality by adding drag state management for the slider thumbs. The most important changes include importing the `useState` hook, adding state management for dragging, and updating the `Tooltip` component to reflect the dragging state.

Enhancements to `RangeSlider` component:

* [`client/src/components/ui/slider.tsx`](diffhunk://#diff-08230162d8629480f37e9758a0ed105d95a0db6ac9a7a39a0e62220ba1c82ae6R4): Imported the `useState` hook from React.
* [`client/src/components/ui/slider.tsx`](diffhunk://#diff-08230162d8629480f37e9758a0ed105d95a0db6ac9a7a39a0e62220ba1c82ae6R62-R65): Added `isDragging` state to manage the dragging state of the left and right slider thumbs.
* [`client/src/components/ui/slider.tsx`](diffhunk://#diff-08230162d8629480f37e9758a0ed105d95a0db6ac9a7a39a0e62220ba1c82ae6L82-R112): Updated the `Tooltip` component to automatically open when the corresponding thumb is being dragged.

Task: https://vizzuality.atlassian.net/browse/TBCCT-201