### PR TITLE
[N/A] adds /my-projects page to auth middleware

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { NextRequestWithAuth, withAuth } from "next-auth/middleware";
 
-const PRIVATE_PAGES = /^(\/profile)/;
+const PRIVATE_PAGES = /^(\/profile|\/my-projects)/;
 
 export default function middleware(req: NextRequestWithAuth) {
   if (PRIVATE_PAGES.test(req.nextUrl.pathname)) {


### PR DESCRIPTION
This pull request includes a small change to the `client/src/middleware.ts` file. The change updates the `PRIVATE_PAGES` regex to include the `/my-projects` path, ensuring that the middleware applies to both `/profile` and `/my-projects`.

* [`client/src/middleware.ts`](diffhunk://#diff-e9afcce1307f539338e73b9d862ceaa5bf8be0ab3d07f702f41e024342ae748cL5-R5): Updated `PRIVATE_PAGES` regex to include `/my-projects`.