### PR TITLE
[N/A] adds query params to /scorecard endpoint

### DIFF
--- a/client/src/containers/overview/table/view/key-costs/index.tsx
+++ b/client/src/containers/overview/table/view/key-costs/index.tsx
@@ -66,11 +66,6 @@ export function KeyCostsTable() {
     {
       query: {
         ...filtersToQueryParams(filters),
-        // fields: TABLE_COLUMNS.map((column) => column.accessorKey),
-        // ...(sorting.length > 0 && {
-        //   sort: sorting.map((sort) => `${sort.desc ? "" : "-"}${sort.id}`),
-        // }),
-        // fields: [''],
         pageNumber: pagination.pageIndex + 1,
         pageSize: pagination.pageSize,
       },

--- a/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
+++ b/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
+import { projectScorecardQuerySchema } from "@shared/contracts/projects.contract";
 import { ProjectScorecardView } from "@shared/entities/project-scorecard.view";
 import { keepPreviousData } from "@tanstack/react-query";
 import {
@@ -14,6 +15,7 @@ import {
 } from "@tanstack/react-table";
 import { useAtom } from "jotai";
 import { ChevronsUpDownIcon } from "lucide-react";
+import { z } from "zod";
 
 import { client } from "@/lib/query-client";
 import { queryKeys } from "@/lib/query-keys";
@@ -45,6 +47,8 @@ import TablePagination, {
 
 import { scorecardFiltersSchema } from "./schema";
 
+type sortFields = z.infer<typeof projectScorecardQuerySchema.shape.sort>;
+
 export function ScoredCardPrioritizationTable() {
   const [tableView] = useTableView();
   const [filters] = useGlobalFilters();
@@ -70,7 +74,16 @@ export function ScoredCardPrioritizationTable() {
     queryKey,
     {
       query: {
-        filter: filtersToQueryParams(filters),
+        ...filtersToQueryParams(filters),
+        costRange: filters.costRange,
+        abatementPotentialRange: filters.abatementPotentialRange,
+        costRangeSelector: filters.costRangeSelector,
+        partialProjectName: filters.keyword,
+        ...(sorting.length > 0 && {
+          sort: sorting.map(
+            (sort) => `${sort.desc ? "" : "-"}${sort.id}`,
+          ) as sortFields,
+        }),
         pageNumber: pagination.pageIndex + 1,
         pageSize: pagination.pageSize,
       },

--- a/shared/contracts/projects.contract.ts
+++ b/shared/contracts/projects.contract.ts
@@ -1,4 +1,3 @@
-import { ProjectScorecard } from "./../entities/project-scorecard.entity";
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
 import {
@@ -16,7 +15,6 @@ import { PaginatedProjectsWithMaximums } from "@shared/dtos/projects/projects.dt
 const contract = initContract();
 
 export type ProjectType = Omit<Project, keyof BaseEntity>;
-export type ProjectScorecardType = Omit<ProjectScorecard, keyof BaseEntity>;
 
 export const otherParams = z.object({
   costRange: z.coerce.number().array().optional(),
@@ -27,7 +25,7 @@ export const otherParams = z.object({
 });
 export const projectsQuerySchema = generateEntityQuerySchema(Project);
 export const projectScorecardQuerySchema =
-  generateEntityQuerySchema(ProjectScorecard);
+  generateEntityQuerySchema(ProjectScorecardView);
 
 export const getProjectsQuerySchema = projectsQuerySchema.merge(otherParams);
 export const getProjectScorecardQuerySchema =


### PR DESCRIPTION
This pull request includes several updates to improve the filtering and sorting functionality in the `KeyCostsTable` and `ScoredCardPrioritizationTable` components, as well as updates to the project contracts.

### Improvements to filtering and sorting:

* [`client/src/containers/overview/table/view/key-costs/index.tsx`](diffhunk://#diff-dfdd1ccddd5007c43db2bf0a58e1445909c68f9c2ca6638d963af5e11a45e3a1L69-L73): Removed commented-out code related to sorting and fields in the query parameters.
* [`client/src/containers/overview/table/view/scorecard-prioritization/index.tsx`](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072L73-R86): Added additional filters (`costRange`, `abatementPotentialRange`, `costRangeSelector`, and `partialProjectName`) and sorting logic to the query parameters.

### Updates to project contracts:

* [`shared/contracts/projects.contract.ts`](diffhunk://#diff-c9b97aa6f1ae834706856581888b50f98001fe75b0bb3ad602eefb5960242ce8L30-R28): Changed the `projectScorecardQuerySchema` to use `ProjectScorecardView` instead of `ProjectScorecard`.

### Codebase maintenance:

* [`client/src/containers/overview/table/view/scorecard-prioritization/index.tsx`](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R6): Added import for `projectScorecardQuerySchema` and `z` from `zod` for type inference. [[1]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R6) [[2]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R18) [[3]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R50-R51)
* [`shared/contracts/projects.contract.ts`](diffhunk://#diff-c9b97aa6f1ae834706856581888b50f98001fe75b0bb3ad602eefb5960242ce8L1): Removed unused import for `ProjectScorecard`.