### PR TITLE
Refactor: standardize table header and cell text styling

### DIFF
--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -58,14 +58,21 @@ const createSegments = (
   ];
 };
 
+const HeaderText = ({ children }: { children: React.ReactNode }) => (
+  <span className="text-xs font-normal">{children}</span>
+);
+const CellText = ({ children }: { children: React.ReactNode }) => (
+  <span className="text-xs font-normal">{children}</span>
+);
+
 export const columns = (filters: z.infer<typeof filtersSchema>) => [
   columnHelper.accessor("projectName", {
     enableSorting: true,
-    header: () => <span>Project Name</span>,
+    header: () => <HeaderText>Project Name</HeaderText>,
   }),
   columnHelper.accessor("scoreCardRating", {
     enableSorting: true,
-    header: () => <span>Scorecard rating</span>,
+    header: () => <HeaderText>Scorecard rating</HeaderText>,
     cell: (props) => {
       const value = props.getValue();
       if (value === undefined) {
@@ -82,20 +89,20 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
     filters.costRangeSelector === "npv" ? "costPerTCO2eNPV" : "costPerTCO2e",
     {
       enableSorting: true,
-      header: () => <span>Cost $(USD)/tCo2</span>,
+      header: () => <HeaderText>Cost $(USD)/tCo2</HeaderText>,
       cell: (props) => {
         const value = props.getValue();
         if (value === null || value === undefined) {
           return "-";
         }
 
-        return formatCurrency(value);
+        return <CellText>{formatCurrency(value)}</CellText>;
       },
     },
   ),
   columnHelper.accessor("abatementPotential", {
     enableSorting: true,
-    header: () => <span>Abatement potential</span>,
+    header: () => <HeaderText>Abatement potential (tCO2e/yr)</HeaderText>,
     cell: (props) => {
       const value = props.getValue();
       if (value === null || value === undefined) {
@@ -119,7 +126,7 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
               },
             ]}
           />
-          <p className="text-sm font-normal">{formatNumber(value)}</p>
+          <CellText>{formatNumber(value)}</CellText>
         </div>
       );
     },
@@ -128,7 +135,13 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
     filters.costRangeSelector === "npv" ? "totalCostNPV" : "totalCost",
     {
       enableSorting: true,
-      header: () => <span>Total Cost (CapEx + OpEx)</span>,
+      header: () => (
+        <HeaderText>
+          Total Cost (<span className="text-sky-blue-500">CapEx</span>
+          &nbsp;+&nbsp;
+          <span className="text-sky-blue-200">OpEx</span>)
+        </HeaderText>
+      ),
       cell: (props) => {
         const value = props.getValue();
         if (value === null || value === undefined) {
@@ -152,7 +165,7 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
                 props.row.original,
               )}
             />
-            <p className="text-sm font-normal">{formatNumber(value)}</p>
+            <CellText>{formatNumber(value)}</CellText>
           </div>
         );
       },

--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -62,7 +62,7 @@ const HeaderText = ({ children }: { children: React.ReactNode }) => (
   <span className="text-xs font-normal">{children}</span>
 );
 const CellText = ({ children }: { children: React.ReactNode }) => (
-  <span className="text-xs font-normal">{children}</span>
+  <span className="text-sm font-normal">{children}</span>
 );
 
 export const columns = (filters: z.infer<typeof filtersSchema>) => [


### PR DESCRIPTION
### Changes
- Added reusable `HeaderText` and `CellText` components for consistent text styling across table
- Standardized font sizes and weights using these components
- Updated column headers with more precise labels (e.g., added "tCO2e/yr" unit)
- Enhanced visual distinction between CapEx and OpEx in Total Cost column using color coding
- Replaced generic `<span>` and `<p>` elements with semantic components

### Visual Changes
- All table headers now use consistent text-xs font size and normal font weight
- All cell values now use consistent text-sm font size and normal font weight
- CapEx (blue-500) and OpEx (blue-200) are now visually distinguished in the Total Cost column header
- Added proper spacing between CapEx and OpEx labels using `&nbsp;`

### Technical Details
- Created two new components:
  - `HeaderText`: Standardizes header text styling
  - `CellText`: Standardizes cell text styling
- Both components maintain consistent `text-xs font-normal` styling

This PR improves the visual consistency and readability of the table while making the code more maintainable through component reuse.

Fixes [Jira comment](https://vizzuality.atlassian.net/browse/TBCCT-179?focusedCommentId=33330)