### PR TITLE
[FE]: Remove "project size" and "carbon pricing type" from project overview detail sidebar

### DIFF
--- a/client/src/app/(overview)/store.ts
+++ b/client/src/app/(overview)/store.ts
@@ -1,10 +1,6 @@
 import { MapMouseEvent } from "react-map-gl";
 
-import {
-  COST_TYPE_SELECTOR,
-  PROJECT_PRICE_TYPE,
-  PROJECT_SIZE_FILTER,
-} from "@shared/entities/projects.entity";
+import { COST_TYPE_SELECTOR } from "@shared/entities/projects.entity";
 import { atom } from "jotai";
 import { z } from "zod";
 
@@ -33,12 +29,10 @@ export const projectDetailsAtom = atom<{
 
 export type ProjectDetailsFilters = Pick<
   z.infer<typeof filtersSchema>,
-  "projectSizeFilter" | "priceType" | "costRangeSelector"
+  "costRangeSelector"
 >;
 
 const INITIAL_FILTERS_STATE: ProjectDetailsFilters = {
-  projectSizeFilter: PROJECT_SIZE_FILTER.MEDIUM,
-  priceType: PROJECT_PRICE_TYPE.MARKET_PRICE,
   costRangeSelector: COST_TYPE_SELECTOR.NPV,
 };
 

--- a/client/src/containers/overview/project-details/index.tsx
+++ b/client/src/containers/overview/project-details/index.tsx
@@ -32,16 +32,12 @@ import {
 } from "@/components/ui/sheet";
 
 export default function ProjectDetails() {
-  const filters = useAtomValue(projectDetailsFiltersAtom);
+  const { costRangeSelector } = useAtomValue(projectDetailsFiltersAtom);
   const [projectDetails, setProjectDetails] = useAtom(projectDetailsAtom);
-  const { costRangeSelector } = filters;
-  const queryKey = queryKeys.projects.one(projectDetails.id, filters).queryKey;
+  const queryKey = queryKeys.projects.one(projectDetails.id).queryKey;
   const { data: projectData } = client.projects.getProject.useQuery(
     queryKey,
     {
-      query: {
-        filter: filters,
-      },
       params: { id: projectDetails.id },
     },
     {

--- a/client/src/containers/overview/project-details/parameters/index.tsx
+++ b/client/src/containers/overview/project-details/parameters/index.tsx
@@ -1,8 +1,4 @@
-import {
-  PROJECT_SIZE_FILTER,
-  COST_TYPE_SELECTOR,
-  PROJECT_PRICE_TYPE,
-} from "@shared/entities/projects.entity";
+import { COST_TYPE_SELECTOR } from "@shared/entities/projects.entity";
 import { useAtom } from "jotai";
 
 import { FILTER_KEYS } from "@/app/(overview)/constants";
@@ -20,41 +16,6 @@ import {
 } from "@/components/ui/select";
 
 export const PROJECT_PARAMETERS: Parameter<keyof ProjectDetailsFilters>[] = [
-  {
-    key: FILTER_KEYS[1],
-    label: "Project size",
-    className: "w-[125px]",
-    options: [
-      {
-        label: PROJECT_SIZE_FILTER.SMALL,
-        value: PROJECT_SIZE_FILTER.SMALL,
-      },
-      {
-        label: PROJECT_SIZE_FILTER.MEDIUM,
-        value: PROJECT_SIZE_FILTER.MEDIUM,
-      },
-      {
-        label: PROJECT_SIZE_FILTER.LARGE,
-        value: PROJECT_SIZE_FILTER.LARGE,
-      },
-    ],
-  },
-  {
-    key: FILTER_KEYS[2],
-    label: "Carbon pricing type",
-    className: "w-[195px]",
-    options: [
-      {
-        label: PROJECT_PRICE_TYPE.MARKET_PRICE,
-        value: PROJECT_PRICE_TYPE.MARKET_PRICE,
-      },
-      {
-        label: PROJECT_PRICE_TYPE.OPEN_BREAK_EVEN_PRICE,
-        value: PROJECT_PRICE_TYPE.OPEN_BREAK_EVEN_PRICE,
-        disabled: true,
-      },
-    ],
-  },
   {
     key: FILTER_KEYS[3],
     label: "Cost",
@@ -79,7 +40,7 @@ export default function ParametersProjects() {
     v: string,
     parameter: keyof ProjectDetailsFilters,
   ) => {
-    setFilters((prev) => ({ ...prev, [parameter]: v }));
+    setFilters((prev) => ({ ...prev, [parameter]: v as COST_TYPE_SELECTOR }));
   };
 
   return (

--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -10,7 +10,6 @@ import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 import { PaginationState, SortingState } from "@tanstack/react-table";
 import { z } from "zod";
 
-import { ProjectDetailsFilters } from "@/app/(overview)/store";
 import { filtersSchema } from "@/app/(overview)/url-store";
 
 import { TABLE_VIEWS } from "@/containers/overview/table/toolbar/table-selector";
@@ -44,7 +43,7 @@ export const tableKeys = createQueryKeys("tables", {
 });
 
 export const projectKeys = createQueryKeys("projects", {
-  one: (id: string, filters: ProjectDetailsFilters) => [id, filters],
+  one: (id: string) => [id],
 });
 
 export const customProjectKeys = createQueryKeys("customProjects", {


### PR DESCRIPTION
## Remove Project Size and Price Type Filters from Project Details

### This PR simplifies the project details view by removing two unused filters: project size and price type. The only remaining filter is the cost range selector (NPV/Total). This change streamlines the UI and removes unnecessary complexity from the codebase.

### Changes:

- Removed projectSizeFilter and priceType from project details filters
- Simplified the project details API query by removing unused filter parameters
- Updated types and interfaces to reflect the reduced filter set
- Removed unused imports from project entities
- Streamlined the parameters component to only show cost selector options


[Jira](https://vizzuality.atlassian.net/browse/TBCCT-218)