### PR TITLE
[FE]: Move "project size" filter to sidebar

### DIFF
--- a/client/src/app/(overview)/url-store.ts
+++ b/client/src/app/(overview)/url-store.ts
@@ -37,7 +37,7 @@ export interface Parameter<T = keyof z.infer<typeof filtersSchema>> {
 
 export const filtersSchema = z.object({
   [FILTER_KEYS[0]]: z.string().optional(),
-  [FILTER_KEYS[1]]: z.nativeEnum(PROJECT_SIZE_FILTER),
+  [FILTER_KEYS[1]]: z.array(z.nativeEnum(PROJECT_SIZE_FILTER)),
   [FILTER_KEYS[2]]: z.nativeEnum(PROJECT_PRICE_TYPE),
   [FILTER_KEYS[3]]: z.nativeEnum(COST_TYPE_SELECTOR),
   [FILTER_KEYS[4]]: z.string().optional(),
@@ -50,7 +50,7 @@ export const filtersSchema = z.object({
 
 export const INITIAL_FILTERS_STATE: z.infer<typeof filtersSchema> = {
   keyword: "",
-  projectSizeFilter: PROJECT_SIZE_FILTER.MEDIUM,
+  projectSizeFilter: [],
   priceType: PROJECT_PRICE_TYPE.MARKET_PRICE,
   costRangeSelector: COST_TYPE_SELECTOR.NPV,
   countryCode: "",

--- a/client/src/containers/overview/filters/index.tsx
+++ b/client/src/containers/overview/filters/index.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { CheckedState } from "@radix-ui/react-checkbox";
 import { ACTIVITY } from "@shared/entities/activity.enum";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
+import { PROJECT_SIZE_FILTER } from "@shared/entities/projects.entity";
 import { useSetAtom } from "jotai/index";
 import { XIcon } from "lucide-react";
 import { useDebounce } from "rooks";
@@ -17,6 +18,8 @@ import {
   INITIAL_FILTERS_STATE,
   useProjectOverviewFilters,
 } from "@/app/(overview)/url-store";
+
+import { FILTERS } from "@/constants/tooltip";
 
 import { Button } from "@/components/ui/button";
 import { CheckboxWrapper } from "@/components/ui/checkbox";
@@ -120,6 +123,18 @@ export default function ProjectsFilters() {
       restorationActivity: isChecked
         ? [...prev.restorationActivity, subActivity]
         : prev.restorationActivity.filter((e) => e !== subActivity),
+    }));
+  };
+
+  const handleProjectSizeChange = async (
+    isChecked: CheckedState,
+    size: PROJECT_SIZE_FILTER,
+  ) => {
+    await setFilters((prev) => ({
+      ...prev,
+      projectSizeFilter: isChecked
+        ? [...prev.projectSizeFilter, size]
+        : prev.projectSizeFilter.filter((e) => e !== size),
     }));
   };
 
@@ -349,6 +364,31 @@ export default function ProjectsFilters() {
           min={formatNumber(INITIAL_ABATEMENT_POTENTIAL_RANGE[0])}
           max={formatNumber(INITIAL_ABATEMENT_POTENTIAL_RANGE[1])}
         />
+      </div>
+
+      <div className="space-y-2">
+        <Label
+          tooltip={{
+            title: "Project size",
+            content: FILTERS.PROJECT_SIZE,
+          }}
+        >
+          Project size
+        </Label>
+        <ul className="flex gap-2">
+          {Object.values(PROJECT_SIZE_FILTER).map((size) => (
+            <li key={size}>
+              <CheckboxWrapper
+                label={size}
+                id={size}
+                checked={filters.projectSizeFilter.includes(size)}
+                onCheckedChange={async (isChecked) => {
+                  await handleProjectSizeChange(isChecked, size);
+                }}
+              />
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );

--- a/client/src/containers/overview/header/parameters/index.tsx
+++ b/client/src/containers/overview/header/parameters/index.tsx
@@ -1,5 +1,4 @@
 import {
-  PROJECT_SIZE_FILTER,
   COST_TYPE_SELECTOR,
   PROJECT_PRICE_TYPE,
 } from "@shared/entities/projects.entity";
@@ -25,26 +24,6 @@ import {
 } from "@/components/ui/select";
 
 export const PROJECT_PARAMETERS: Parameter[] = [
-  {
-    key: FILTER_KEYS[1],
-    label: "Project size",
-    className: "w-[125px]",
-    tooltipContent: FILTERS.PROJECT_SIZE,
-    options: [
-      {
-        label: PROJECT_SIZE_FILTER.SMALL,
-        value: PROJECT_SIZE_FILTER.SMALL,
-      },
-      {
-        label: PROJECT_SIZE_FILTER.MEDIUM,
-        value: PROJECT_SIZE_FILTER.MEDIUM,
-      },
-      {
-        label: PROJECT_SIZE_FILTER.LARGE,
-        value: PROJECT_SIZE_FILTER.LARGE,
-      },
-    ],
-  },
   {
     key: FILTER_KEYS[2],
     label: "Carbon pricing type",


### PR DESCRIPTION
This pull request introduces enhancements to the project size filter functionality. The `projectSizeFilter` has been modified to allow multiple selections by changing its type from a single enum value to an array. The initial state is now set to an empty array. 

Additionally, the `ProjectsFilters` component has been updated to include checkboxes for each project size, enabling users to select multiple sizes. The project size parameter definition has been removed from the `PROJECT_PARAMETERS` as it is now handled within the filters component. 

[Jira](https://vizzuality.atlassian.net/browse/TBCCT-220)
