### PR TITLE
fix(api): Change Project Maximum total abatement cost and total cost …

### DIFF
--- a/api/src/modules/projects/projects.service.ts
+++ b/api/src/modules/projects/projects.service.ts
@@ -28,17 +28,16 @@ export class ProjectsService extends AppBaseService<
   public async findAllProjectsWithMaximums(
     query: ProjectFetchSpecificacion,
   ): Promise<PaginatedProjectsWithMaximums> {
-    // Elena told us that the maximum values of the abatement_potential and max_total_cost bars is the sum of all values of the filtered results
     const qb = this.dataSource
       .createQueryBuilder()
-      .select('SUM(abatement_potential)::BIGINT', 'maxAbatementPotential')
+      .select('MAX(abatement_potential)', 'maxAbatementPotential')
       .from(Project, 'project');
 
     const { costRangeSelector } = query;
     if (costRangeSelector == COST_TYPE_SELECTOR.NPV) {
-      qb.addSelect('SUM(capex_npv + opex_npv)::BIGINT', 'maxTotalCost');
+      qb.addSelect('MAX(capex_npv + opex_npv)', 'maxTotalCost');
     } else {
-      qb.addSelect('SUM(capex + opex)::BIGINT', 'maxTotalCost');
+      qb.addSelect('MAX(capex + opex)', 'maxTotalCost');
     }
 
     const totalsQuery = this.applySearchFiltersToQueryBuilder(qb, query);

--- a/api/test/integration/projects/projects.spec.ts
+++ b/api/test/integration/projects/projects.spec.ts
@@ -3,7 +3,11 @@ import { HttpStatus } from '@nestjs/common';
 import { projectsContract } from '@shared/contracts/projects.contract';
 import { Country } from '@shared/entities/country.entity';
 import { ProjectScorecard } from '@shared/entities/project-scorecard.entity';
-import { Project, PROJECT_SIZE_FILTER } from '@shared/entities/projects.entity';
+import {
+  COST_TYPE_SELECTOR,
+  Project,
+  PROJECT_SIZE_FILTER,
+} from '@shared/entities/projects.entity';
 
 describe('Projects', () => {
   let testManager: TestManager;
@@ -419,15 +423,15 @@ describe('Projects', () => {
       await testManager.mocks().createProject({
         id: 'e934e9fe-a79c-40a5-8254-8817851764ad',
         projectName: 'PROJ_ABC',
-        totalCost: 100,
-        totalCostNPV: 50,
+        capexNPV: 27,
+        opexNPV: 23,
         abatementPotential: 10,
       });
       await testManager.mocks().createProject({
         id: 'e934e9fe-a79c-40a5-8254-8817851764ae',
         projectName: 'PROJ_DEF',
-        totalCost: 200,
-        totalCostNPV: 100,
+        capexNPV: 12,
+        opexNPV: 36,
         abatementPotential: 20,
       });
 
@@ -437,13 +441,14 @@ describe('Projects', () => {
         .query({
           withMaximums: true,
           partialProjectName: 'PROJ',
+          costRangeSelector: COST_TYPE_SELECTOR.NPV,
         });
 
       expect(response.status).toBe(HttpStatus.OK);
       expect(response.body.data).toHaveLength(2);
       expect(response.body.maximums).toEqual({
-        maxAbatementPotential: 30,
-        maxTotalCost: 200,
+        maxAbatementPotential: 20,
+        maxTotalCost: 50,
       });
     });
 


### PR DESCRIPTION
This pull request includes significant changes to the `ProjectsService` and related tests to modify the way maximum values are calculated and to update test cases accordingly. The most important changes are as follows:

### Changes to Maximum Value Calculations:
* [`api/src/modules/projects/projects.service.ts`](diffhunk://#diff-f4e9fe665933514d01aa02820eac87bc916dc468d4f5cb3e4ad50901c441417aL31-R40): Changed the calculation of maximum values for `abatement_potential` and `total_cost` from using `SUM` to `MAX`.

### Updates to Test Cases:
* [`api/test/integration/projects/projects.spec.ts`](diffhunk://#diff-8d9e3a7c7767f19e943245dbb202976e0fd70dcf9f29cd06449eba72dc7be692L6-R10): Updated imports to include `COST_TYPE_SELECTOR` from `projects.entity`.
* [`api/test/integration/projects/projects.spec.ts`](diffhunk://#diff-8d9e3a7c7767f19e943245dbb202976e0fd70dcf9f29cd06449eba72dc7be692L422-R434): Modified test project creation to use `capexNPV` and `opexNPV` instead of `totalCost` and `totalCostNPV`.
* [`api/test/integration/projects/projects.spec.ts`](diffhunk://#diff-8d9e3a7c7767f19e943245dbb202976e0fd70dcf9f29cd06449eba72dc7be692R444-R451): Added `costRangeSelector` parameter to query in tests and updated expected maximum values.