### PR TITLE
Endpoint for updating custom projects

### DIFF
--- a/api/src/modules/custom-projects/custom-projects.service.ts
+++ b/api/src/modules/custom-projects/custom-projects.service.ts
@@ -145,7 +145,7 @@ export class CustomProjectsService extends AppBaseService<
     return query;
   }
 
-  async canUserDeleteProjects(
+  async areProjectsCreatedByUser(
     userId: string,
     projectIds: string[],
   ): Promise<boolean> {

--- a/api/test/integration/custom-projects/custom-projects-update.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-update.spec.ts
@@ -1,0 +1,89 @@
+import { TestManager } from '../../utils/test-manager';
+import { customProjectContract } from '@shared/contracts/custom-projects.contract';
+import { User } from '@shared/entities/users/user.entity';
+
+describe('Update custom projects', () => {
+  let testManager: TestManager;
+  let jwtToken: string;
+  let user: User;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager();
+  });
+
+  beforeEach(async () => {
+    ({ jwtToken, user } = await testManager.setUpTestUser());
+    await testManager.ingestCountries();
+    await testManager.ingestExcel(jwtToken);
+  });
+
+  afterEach(async () => {
+    await testManager.clearDatabase();
+  });
+
+  afterAll(async () => {
+    await testManager.close();
+  });
+
+  describe('Update Custom Projects', () => {
+    test('An authenticated user should be able to update/edit one of their custom projects by id', async () => {
+      // Given
+      const customProject = await testManager.mocks().createCustomProject({
+        user: { id: user.id } as User,
+        projectName: 'A',
+      });
+
+      // When
+      const response = await testManager
+        .request()
+        .patch(
+          `${customProjectContract.updateCustomProject.path.replace(':id', customProject.id)}`,
+        )
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          projectName: 'B',
+        });
+
+      // Then
+      expect(response.status).toBe(200);
+      expect(response.body.projectName).toBe('B');
+    });
+
+    test('An authenticated user should not be able to update projects that do not belong to them', async () => {
+      // Given a custom project exists
+      const customProject = await testManager.mocks().createCustomProject();
+
+      // When updating the custom project
+      const response = await testManager
+        .request()
+        .patch(
+          `${customProjectContract.updateCustomProject.path.replace(':id', customProject.id)}`,
+        )
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          projectName: 'B',
+        });
+
+      // Then
+      expect(response.status).toBe(401);
+    });
+
+    test('An unauthenticated user should not be able to update a custom project', async () => {
+      // Given a custom project exists
+      const customProject = await testManager.mocks().createCustomProject();
+
+      // When updating the custom project
+      const response = await testManager
+        .request()
+        .patch(
+          `${customProjectContract.updateCustomProject.path.replace(':id', customProject.id)}`,
+        )
+        .send({
+          projectName: 'B',
+        });
+
+      // Then
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/shared/contracts/custom-projects.contract.ts
+++ b/shared/contracts/custom-projects.contract.ts
@@ -72,6 +72,18 @@ export const customProjectContract = contract.router({
     },
     body: CreateCustomProjectSchema,
   },
+  updateCustomProject: {
+    method: "PATCH",
+    path: "/custom-projects/:id",
+    pathParams: z.object({
+      id: z.coerce.string(),
+    }),
+    responses: {
+      201: contract.type<CustomProject>(),
+    },
+    body: contract.type<Partial<CustomProject>>(),
+    summary: "Update an existing custom-project",
+  },
   getCustomProjects: {
     method: "GET",
     path: "/custom-projects",


### PR DESCRIPTION
This pull request introduces a new feature to update custom projects within the `CustomProjectsController` and includes corresponding changes in the service, contract, and tests. The most important changes are listed below:

### Controller Enhancements:
* Added a new `updateCustomProject` method to `CustomProjectsController`. This method checks if the user has the necessary permissions and if they created the project before allowing updates.

### Service Updates:
* Renamed the method `canUserDeleteProjects` to `areProjectsCreatedByUser` in `CustomProjectsService` for better clarity and consistency.

### Contract Modifications:
* Added a new route `updateCustomProject` in `customProjectContract` to define the API endpoint for updating custom projects. 

### Test Additions:
* Created a new integration test suite `custom-projects-update.spec.ts` to test the update functionality. This includes tests for authenticated users updating their own projects, users attempting to update projects they do not own, and unauthenticated users.
