### PR TITLE
fix: disable retry on token validation query

### DIFF
--- a/client/src/components/session-checker/index.tsx
+++ b/client/src/components/session-checker/index.tsx
@@ -37,6 +37,7 @@ export default function SessionChecker() {
     {
       queryKey,
       enabled: queryEnabled,
+      retry: false,
     },
   );
 


### PR DESCRIPTION
## Disable Token Validation Retry

## Changes
- Added `retry: false` to the token validation query options to prevent unnecessary retry attempts when the token is invalid

## Why
When a token is invalid, retrying the validation query is unnecessary and can cause unwanted side effects. This change ensures we immediately handle the invalid token case by signing out the user instead of attempting multiple validation requests.