### PR TITLE
Bugix/price type filter

### DIFF
--- a/client/src/containers/overview/header/parameters/index.tsx
+++ b/client/src/containers/overview/header/parameters/index.tsx
@@ -37,7 +37,6 @@ export const PROJECT_PARAMETERS: Parameter[] = [
       {
         label: PROJECT_PRICE_TYPE.OPEN_BREAK_EVEN_PRICE,
         value: PROJECT_PRICE_TYPE.OPEN_BREAK_EVEN_PRICE,
-        disabled: true,
       },
     ],
   },

--- a/client/src/containers/overview/table/utils.ts
+++ b/client/src/containers/overview/table/utils.ts
@@ -11,7 +11,6 @@ const OMITTED_FIELDS = [
   "costRange",
   "abatementPotentialRange",
   "costRangeSelector",
-  "priceType",
 ];
 
 export const filtersToQueryParams = (

--- a/e2e/page-objects.ts
+++ b/e2e/page-objects.ts
@@ -1,0 +1,1 @@
+export const PROJECT_OVERVIEW_TABLE_LOCATOR = 'table tbody tr'

--- a/shared/lib/e2e-test-manager.ts
+++ b/shared/lib/e2e-test-manager.ts
@@ -1,7 +1,7 @@
 import { DataSource } from "typeorm";
 import { User } from "@shared/entities/users/user.entity";
 import {createProject, createUser} from "@shared/lib/entity-mocks";
-import { clearTestDataFromDatabase } from "@shared/lib/db-helpers";
+import {clearTablesByEntities, clearTestDataFromDatabase} from "@shared/lib/db-helpers";
 import { JwtPayload, sign } from "jsonwebtoken";
 import { TOKEN_TYPE_ENUM } from "@shared/schemas/auth/token-type.schema";
 import { COMMON_DATABASE_ENTITIES } from "@shared/lib/db-entities";
@@ -37,6 +37,10 @@ export class E2eTestManager {
 
   async clearDatabase() {
     await clearTestDataFromDatabase(this.dataSource);
+  }
+
+  async clearTablesByEntities(entities: any[]) {
+   await clearTablesByEntities(this.dataSource, entities);
   }
 
   getDataSource() {


### PR DESCRIPTION
Fixes the missing price type query param that effectively duplicates the number of projects that should be shown at a time. Additionally, it activates the Open break even price filter which was previously disabled.

Tests included

### Changes to project parameters and filtering:

* [`client/src/containers/overview/header/parameters/index.tsx`](diffhunk://#diff-4f3cc66ba3f5631cf9d2428f883e216c13b143e2d37a44a6d1812f380106781cL40): Enabled the previously disabled project price type parameter.
* [`client/src/containers/overview/table/utils.ts`](diffhunk://#diff-ee924a47627220e1d7ecf5285ce198ead9fcd01971068deaa1f1890db98c0d00L14): Removed `priceType` from the omitted fields to allow filtering by price type.

### Enhancements to end-to-end testing:

* [`e2e/page-objects.ts`](diffhunk://#diff-5609d9303bb75b68dc4610bef3c061c877d0c781fe94131f5c844cec3ea94dc3R1): Added a new locator `PROJECT_OVERVIEW_TABLE_LOCATOR` for the project overview table rows.
* `e2e/tests/projects/projects-overview-table.spec.ts`: 
  * Imported `Project`, `PROJECT_PRICE_TYPE`, and `PROJECT_OVERVIEW_TABLE_LOCATOR`.
  * Added a new test to verify filtering by price type and updated the existing test to use the new locator. [[1]](diffhunk://#diff-4b07e3a3b7383972f20ec23766714e96b4b61c8926022fa570a5ba9cf4efbdbbR19-R51) [[2]](diffhunk://#diff-4b07e3a3b7383972f20ec23766714e96b4b61c8926022fa570a5ba9cf4efbdbbL32-R61)

### Improvements to test management:

* `shared/lib/e2e-test-manager.ts`: 
  * Imported `clearTablesByEntities` and added a new method `clearTablesByEntities` in the `E2eTestManager` class. [[1]](diffhunk://#diff-65172d02c60a949fa1d49c1b43d3c8b9db6ea3bb788111c4dd6d82a64e2b6c4eL4-R4) [[2]](diffhunk://#diff-65172d02c60a949fa1d49c1b43d3c8b9db6ea3bb788111c4dd6d82a64e2b6c4eR42-R45)