### PR TITLE
[TBCCT-249] feat(api): Ensure that the project scorecards are wiped before new ones are imported

### DIFF
--- a/api/src/modules/import/import.repostiory.ts
+++ b/api/src/modules/import/import.repostiory.ts
@@ -34,7 +34,11 @@ export class ImportRepository {
   constructor(private readonly dataSource: DataSource) {}
 
   async importProjectScorecard(projectScorecards: ProjectScorecard[]) {
-    return this.dataSource.transaction(async (manager) => {
+    return this.dataSource.transaction('READ COMMITTED', async (manager) => {
+      // Wipe current project scorecards
+      await manager.clear(ProjectScorecard);
+
+      // Insert
       await manager.save(projectScorecards);
     });
   }

--- a/api/test/integration/import/import.repository.spec.ts
+++ b/api/test/integration/import/import.repository.spec.ts
@@ -1,0 +1,38 @@
+import { ProjectScorecard } from '@shared/entities/project-scorecard.entity';
+import { TestManager } from 'api/test/utils/test-manager';
+
+describe('Import Repository', () => {
+  let testManager: TestManager;
+  let jwtToken: string;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager();
+    const response = await testManager.setUpTestUser();
+    jwtToken = response.jwtToken;
+  });
+
+  afterEach(async () => {
+    await testManager.clearDatabase();
+  });
+
+  afterAll(async () => {
+    await testManager.close();
+  });
+
+  it('should wipe previous project scorecards before importing new ones', async () => {
+    // Given
+    await testManager.ingestCountries();
+    await testManager.ingestProjectScoreCards(jwtToken);
+    const scorecardRepository =
+      testManager.dataSource.getRepository(ProjectScorecard);
+
+    const scorecardCount = await scorecardRepository.count();
+
+    // When
+    await testManager.ingestProjectScoreCards(jwtToken);
+    const latestScorecardCount = await scorecardRepository.count();
+
+    // Then
+    expect(scorecardCount).toEqual(latestScorecardCount);
+  });
+});


### PR DESCRIPTION
This pull request includes changes to the `ImportRepository` class and adds new integration tests to ensure the correct behavior of the import functionality.

Changes to the `ImportRepository` class:

* [`api/src/modules/import/import.repository.ts`](diffhunk://#diff-a7f7a9963ea5c5c2c3ea37d5ac6e435be607b406814aa09d2811ff7163019358L37-R41): Modified the `importProjectScorecard` method to use the 'READ COMMITTED' isolation level and added logic to clear existing project scorecards before saving new ones.

Addition of integration tests:

* [`api/test/integration/import/import.repository.spec.ts`](diffhunk://#diff-34dc2be2409c131573dd04ec806227faa059af897eb9632fd762cf13ad080d41R1-R38): Added new integration tests to verify that previous project scorecards are wiped before importing new ones. This includes setup and teardown logic to manage the test environment and assertions to confirm the correct behavior.