### PR TITLE
fix: ensure default sorting persists in overview table

### DIFF
--- a/client/src/containers/overview/table/view/overview/index.tsx
+++ b/client/src/containers/overview/table/view/overview/index.tsx
@@ -78,7 +78,16 @@ export function OverviewTable() {
   const handleSortingChange = (updater: Updater<SortingState>) => {
     const newSorting =
       typeof updater === "function" ? updater(sorting) : updater;
-    setSorting(newSorting.length === 0 ? DEFAULT_SORTING : newSorting);
+
+    // We want to toggle projectName between asc/desc only (other columns can be asc/desc/none)
+    if (
+      newSorting.length === 0 &&
+      sorting.some((s) => s.id === "projectName")
+    ) {
+      setSorting([{ id: "projectName", desc: false }]);
+    } else {
+      setSorting(newSorting.length === 0 ? DEFAULT_SORTING : newSorting);
+    }
   };
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,

--- a/client/src/containers/overview/table/view/overview/index.tsx
+++ b/client/src/containers/overview/table/view/overview/index.tsx
@@ -14,6 +14,7 @@ import {
   SortingState,
   useReactTable,
   TableState,
+  Updater,
 } from "@tanstack/react-table";
 import { useAtom } from "jotai";
 import { ChevronsUpDownIcon } from "lucide-react";
@@ -62,17 +63,23 @@ export interface TableStateWithMaximums extends TableState {
   };
 }
 
+const DEFAULT_SORTING: SortingState = [
+  {
+    id: "projectName",
+    desc: true,
+  },
+];
+
 export function OverviewTable() {
   const [tableView] = useTableView();
   const [filters] = useProjectOverviewFilters();
   const [, setProjectDetails] = useAtom(projectDetailsAtom);
-  const [sorting, setSorting] = useState<SortingState>([
-    {
-      id: "projectName",
-      desc: true,
-    },
-  ]);
-
+  const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
+  const handleSortingChange = (updater: Updater<SortingState>) => {
+    const newSorting =
+      typeof updater === "function" ? updater(sorting) : updater;
+    setSorting(newSorting.length === 0 ? DEFAULT_SORTING : newSorting);
+  };
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: Number.parseInt(PAGINATION_SIZE_OPTIONS[0]),
@@ -149,7 +156,7 @@ export function OverviewTable() {
       pagination,
       maximums,
     } as TableStateWithMaximums,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     onPaginationChange: setPagination,
   });
 


### PR DESCRIPTION
## Overview
This PR improves the sorting behavior of the overview table by ensuring it always maintains a default sort state.

## Changes
- Added a `DEFAULT_SORTING` constant for better maintainability
- Implemented a sorting handler that enforces default sorting when all sorts are cleared
- Table now consistently sorts by project name (descending) when no other sort is applied

## Jira
[TBCCT-253](https://vizzuality.atlassian.net/browse/TBCCT-253)

## Testing
- [ ] Verify table defaults to project name sorting on initial load
- [ ] Confirm default sorting is restored when clearing all column sorts
- [ ] Check that existing sort functionality works as expected

[TBCCT-253]: https://vizzuality.atlassian.net/browse/TBCCT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ