### PR TITLE
[bug/TBCCT-268] Fix integration between adminjs and API. The request made by adminjs to the API are authenticated via session cookie

### DIFF
--- a/api/src/modules/admin/admin.controller.ts
+++ b/api/src/modules/admin/admin.controller.ts
@@ -1,15 +1,15 @@
 import { Controller, Headers, UseGuards } from '@nestjs/common';
 import { RolesGuard } from '@api/modules/auth/guards/roles.guard';
-import { JwtAuthGuard } from '@api/modules/auth/guards/jwt-auth.guard';
 import { RequiredRoles } from '@api/modules/auth/decorators/roles.decorator';
 import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
 import { ControllerResponse } from '@api/types/controller-response.type';
 import { adminContract } from '@shared/contracts/admin.contract';
 import { AuthenticationService } from '@api/modules/auth/authentication.service';
 import { ROLES } from '@shared/entities/users/roles.enum';
+import { JwtCookieAuthGuard } from '@api/modules/auth/guards/jwt-cookie-auth.guard';
 
 @Controller()
-@UseGuards(JwtAuthGuard, RolesGuard)
+@UseGuards(JwtCookieAuthGuard, RolesGuard)
 @RequiredRoles(ROLES.ADMIN)
 export class AdminController {
   constructor(private readonly auth: AuthenticationService) {}

--- a/backoffice/resources/users/user.actions.ts
+++ b/backoffice/resources/users/user.actions.ts
@@ -20,10 +20,11 @@ export const createUserAction = async (
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
           Origin: response.req.headers.origin,
+          Cookie: response.req.headers.cookie, // Resend the the client cookies to the API to authenticate the admin via session cookie
         },
         body: JSON.stringify(request.payload),
+
       });
 
       if (!apiResponse.ok) {


### PR DESCRIPTION
This pull request includes changes to the authentication mechanism in the admin module and user actions. The most important changes are:

Authentication mechanism updates:

* [`api/src/modules/admin/admin.controller.ts`](diffhunk://#diff-a106c988378f0b821c80c0e990def2145a84cc09c93798bb0bbfbe89ffe59cf8L3-R12): Replaced `JwtAuthGuard` with `JwtCookieAuthGuard` in the `AdminController` to switch from token-based to cookie-based authentication.

User action updates:

* [`backoffice/resources/users/user.actions.ts`](diffhunk://#diff-ebd7fd4dbe721eb4dc96e7ecf7957964e1a67f48545dbae592e2b8bdf60b9831L23-R27): Changed the authorization method in `createUserAction` to use cookies instead of the `Authorization` header for session-based authentication.