### PR TITLE
fix: session handling and private routes

### DIFF
--- a/client/src/components/session-checker/index.tsx
+++ b/client/src/components/session-checker/index.tsx
@@ -21,8 +21,10 @@ export default function SessionChecker() {
 
   const pathname = usePathname();
   const queryEnabled = useMemo(
-    () => isPrivatePath(pathname) && !!session?.accessToken,
-    [session?.accessToken, pathname],
+    // Always check if the user is logged in, regardless of the path
+    // so the sidebar items can update accordingly
+    () => !!session?.accessToken,
+    [session?.accessToken],
   );
   const { error } = client.auth.validateToken.useQuery(
     queryKey,
@@ -44,7 +46,7 @@ export default function SessionChecker() {
   useEffect(() => {
     if (error && queryEnabled) {
       signOut({
-        redirect: true,
+        redirect: isPrivatePath(pathname),
         callbackUrl: queryEnabled ? "/auth/signin" : undefined,
       });
     }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -44,7 +44,8 @@ export const parseTableData = <
   }));
 };
 
-const PRIVATE_PAGES = /^(\/profile|\/my-projects)/;
+const PRIVATE_PAGES =
+  /^(\/profile|\/my-projects|\/projects\/[a-f0-9-]+(?:\/edit)?)/;
 export const isPrivatePath = (pathname: string) => {
   return PRIVATE_PAGES.test(pathname);
 };


### PR DESCRIPTION
## Session Management & Route Protection Updates

### Changes
- Updated private routes to include project detail and edit pages (`/projects/[uuid]` and `/projects/[uuid]/edit`)
- Modified session checker to validate accesstoken globally instead of only on private routes
- Updated sign-out behavior to redirect only when on private paths

### Why
This improves the user experience by maintaining consistent session state across all pages while ensuring proper authentication for protected routes. The sidebar navigation will now correctly reflect the user's login status regardless of which page they're viewing.
