### PR TITLE
feat(api): Create a zod schema to validate the environment configuration

### DIFF
--- a/api/src/modules/config/app-config.module.ts
+++ b/api/src/modules/config/app-config.module.ts
@@ -4,6 +4,7 @@ import { ApiConfigService } from '@api/modules/config/app-config.service';
 import { DatabaseModule } from '@api/modules/config/database/database.module';
 import { resolveConfigPath } from '@api/modules/config/path-resolver';
 import { JwtConfigHandler } from '@api/modules/config/auth-config.handler';
+import { validateEnvConfig } from '@api/modules/config/env-config.schema';
 
 @Global()
 @Module({
@@ -14,31 +15,11 @@ import { JwtConfigHandler } from '@api/modules/config/auth-config.handler';
     ConfigModule.forRoot({
       isGlobal: true,
       cache: true,
-      // TODO: This is a bit ugly, we should find a way to make this more elegant
       envFilePath: [
         resolveConfigPath(`shared/config/.env.${process.env.NODE_ENV}`),
         resolveConfigPath(`shared/config/.env`),
       ],
-      validate(config) {
-        const expectedVariables = [
-          'BACKOFFICE_SESSION_COOKIE_NAME',
-          'BACKOFFICE_SESSION_COOKIE_SECRET',
-        ];
-
-        const missingVariables = [];
-        for (const expectedVariable of expectedVariables) {
-          if (config[expectedVariable] === undefined) {
-            missingVariables.push(expectedVariable);
-          }
-        }
-
-        if (missingVariables.length > 0) {
-          throw new Error(
-            `Missing required environment variables: ${missingVariables.join(', ')}`,
-          );
-        }
-        return config;
-      },
+      validate: validateEnvConfig,
     }),
     DatabaseModule,
   ],

--- a/api/src/modules/config/env-config.schema.ts
+++ b/api/src/modules/config/env-config.schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const EXPIRES_IN_REGEX = /^[0-9]+\w$/;
+
+const envConfigSchema = z
+  .object({
+    NODE_ENV: z.string().default('development'),
+    DB_HOST: z.string(),
+    DB_PORT: z.coerce.number(),
+    DB_NAME: z.string(),
+    DB_USERNAME: z.string(),
+    DB_PASSWORD: z.string(),
+
+    API_URL: z.string(),
+    ACCESS_TOKEN_SECRET: z.string(),
+    ACCESS_TOKEN_EXPIRES_IN: z.string().regex(EXPIRES_IN_REGEX),
+
+    ACCOUNT_CONFIRMATION_TOKEN_SECRET: z.string(),
+    ACCOUNT_CONFIRMATION_EXPIRES_IN: z.string().regex(EXPIRES_IN_REGEX),
+    RESET_PASSWORD_TOKEN_SECRET: z.string(),
+    RESET_PASSWORD_TOKEN_EXPIRES_IN: z.string().regex(EXPIRES_IN_REGEX),
+    EMAIL_CONFIRMATION_TOKEN_SECRET: z.string(),
+    EMAIL_CONFIRMATION_TOKEN_EXPIRES_IN: z.string().regex(EXPIRES_IN_REGEX),
+
+    AWS_SES_ACCESS_KEY_ID: z.string(),
+    AWS_SES_ACCESS_KEY_SECRET: z.string(),
+    AWS_SES_DOMAIN: z.string(),
+    AWS_REGION: z.string(),
+
+    BACKOFFICE_SESSION_COOKIE_NAME: z.string(),
+    BACKOFFICE_SESSION_COOKIE_SECRET: z.string(),
+  })
+  .passthrough();
+
+export const validateEnvConfig = (config: Record<string, string>) => {
+  return envConfigSchema.parse(config);
+};


### PR DESCRIPTION
This pull request introduces changes to improve the validation of environment variables in the configuration module. The primary changes include the addition of a new schema validation using `zod` and the removal of the previous manual validation logic.

### Improvements to environment variable validation:

* [`api/src/modules/config/app-config.module.ts`](diffhunk://#diff-e132909938ae0bb299f3f36bdc9e110c1b52f5a5407ff9593894a94874fc5f0aR7): Added the import for `validateEnvConfig` and replaced the manual validation logic with the new `validateEnvConfig` function. [[1]](diffhunk://#diff-e132909938ae0bb299f3f36bdc9e110c1b52f5a5407ff9593894a94874fc5f0aR7) [[2]](diffhunk://#diff-e132909938ae0bb299f3f36bdc9e110c1b52f5a5407ff9593894a94874fc5f0aL17-R22)

* [`api/src/modules/config/env-variables-config.schema.ts`](diffhunk://#diff-44cf39540f80c68fa35180ed9250545ad4bd2344f94d635da1e28fc16e5de481R1-R37): Introduced a new `envConfigSchema` using `zod` to define the expected environment variables and their validation rules. Added the `validateEnvConfig` function to parse and validate the configuration using the schema.