### PR TITLE
Add filtering bounds endpoint

### DIFF
--- a/api/src/modules/projects/projects.controller.ts
+++ b/api/src/modules/projects/projects.controller.ts
@@ -42,6 +42,17 @@ export class ProjectsController {
     );
   }
 
+  @TsRestHandler(projectsContract.getProjectsFiltersBounds)
+  async getProjectsFiltersBounds(): ControllerResponse {
+    return tsRestHandler(
+      projectsContract.getProjectsFiltersBounds,
+      async ({ query }) => {
+        const data = await this.projectsService.getProjectsFiltersBounds(query);
+        return { body: { data }, status: HttpStatus.OK };
+      },
+    );
+  }
+
   @TsRestHandler(projectsContract.getProjectsScorecard)
   async getProjectsScorecard(): ControllerResponse {
     return tsRestHandler(

--- a/api/src/modules/projects/projects.service.ts
+++ b/api/src/modules/projects/projects.service.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { getProjectsQuerySchema } from '@shared/contracts/projects.contract';
 import { PaginatedProjectsWithMaximums } from '@shared/dtos/projects/projects.dto';
 import { PROJECT_KEY_COSTS_FIELDS } from '@shared/dtos/projects/project-key-costs.dto';
+import { ProjectsFiltersBoundsDto } from '@shared/dtos/projects/projects-filters-bounds.dto';
 
 export type ProjectFetchSpecificacion = z.infer<typeof getProjectsQuerySchema>;
 
@@ -118,5 +119,107 @@ export class ProjectsService extends AppBaseService<
   ) {
     fetchSpecification.fields = [...PROJECT_KEY_COSTS_FIELDS];
     return this.findAllPaginated(fetchSpecification);
+  }
+
+  public async getProjectsFiltersBounds(
+    fetchSpecification: ProjectFetchSpecificacion,
+  ): Promise<ProjectsFiltersBoundsDto> {
+    const defaultBounds = await this.getDefaultBounds();
+    let costBounds = await this.getCostBounds(fetchSpecification);
+    let abatementBounds = await this.getAbatementBounds(fetchSpecification);
+
+    if (costBounds.min === 0 && costBounds.max === 0) {
+      costBounds = defaultBounds.costBounds;
+    }
+    if (abatementBounds.min === 0 && abatementBounds.max === 0) {
+      abatementBounds = defaultBounds.abatementBounds;
+    }
+
+    return {
+      cost: { ...costBounds },
+      abatementPotential: { ...abatementBounds },
+    };
+  }
+
+  private async getDefaultBounds(): Promise<{
+    costBounds: { min: number; max: number };
+    abatementBounds: { min: number; max: number };
+  }> {
+    const costBounds = await this.dataSource
+      .createQueryBuilder()
+      .select('MAX(total_cost)', 'maxCost')
+      .addSelect('MIN(total_cost)', 'minCost')
+      .from(Project, 'project')
+      .execute();
+
+    const abatementBounds = await this.dataSource
+      .createQueryBuilder()
+      .select('MAX(abatement_potential)', 'maxAbatementPotential')
+      .addSelect('MIN(abatement_potential)', 'minAbatementPotential')
+      .from(Project, 'project')
+      .execute();
+
+    return {
+      costBounds: {
+        min: Number(costBounds[0].minCost),
+        max: Number(costBounds[0].maxCost),
+      },
+      abatementBounds: {
+        min: Number(abatementBounds[0].minAbatementPotential),
+        max: Number(abatementBounds[0].maxAbatementPotential),
+      },
+    };
+  }
+
+  private async getAbatementBounds(
+    fetchSpecification: ProjectFetchSpecificacion,
+  ): Promise<{ min: number; max: number }> {
+    // Do not filter by cost to get the cost bounds
+    const abatementQuery = structuredClone(fetchSpecification);
+    delete abatementQuery.costRange;
+    delete abatementQuery.costRangeSelector;
+
+    let abatementBoundsQB = this.dataSource.createQueryBuilder();
+    this.setFilters(abatementBoundsQB, fetchSpecification.filter);
+    this.applySearchFiltersToQueryBuilder(abatementBoundsQB, abatementQuery);
+
+    const abatementBounds = await abatementBoundsQB
+      .select('MAX(abatement_potential)', 'maxAbatementPotential')
+      .addSelect('MIN(abatement_potential)', 'minAbatementPotential')
+      .from(Project, 'project')
+      .execute();
+    return {
+      min: Number(abatementBounds[0].minAbatementPotential),
+      max: Number(abatementBounds[0].maxAbatementPotential),
+    };
+  }
+
+  private async getCostBounds(
+    fetchSpecification: ProjectFetchSpecificacion,
+  ): Promise<{ min: number; max: number }> {
+    // Do not filter by abatement potential to get the abatement bounds
+    const costQuery = structuredClone(fetchSpecification);
+    delete costQuery.abatementPotentialRange;
+
+    let costBoundsQB = this.dataSource.createQueryBuilder();
+    this.setFilters(costBoundsQB, fetchSpecification.filter);
+    this.applySearchFiltersToQueryBuilder(costBoundsQB, costQuery);
+
+    switch (fetchSpecification.costRangeSelector) {
+      case 'npv':
+        costBoundsQB.addSelect('MAX(total_cost_npv)', 'maxCost');
+        costBoundsQB.addSelect('MIN(total_cost_npv)', 'minCost');
+        break;
+      case 'total':
+      default:
+        costBoundsQB.addSelect('MAX(total_cost)', 'maxCost');
+        costBoundsQB.addSelect('MIN(total_cost)', 'minCost');
+        break;
+    }
+    const costBounds = await costBoundsQB.from(Project, 'project').execute();
+    return {
+      min: Number(costBounds[0].minCost),
+      max: Number(costBounds[0].maxCost),
+    };
   }
 }

--- a/api/test/integration/projects/projects.spec.ts
+++ b/api/test/integration/projects/projects.spec.ts
@@ -1,7 +1,9 @@
 import { TestManager } from '../../utils/test-manager';
 import { HttpStatus } from '@nestjs/common';
 import { projectsContract } from '@shared/contracts/projects.contract';
+import { ACTIVITY } from '@shared/entities/activity.enum';
 import { Country } from '@shared/entities/country.entity';
+import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import { ProjectScorecard } from '@shared/entities/project-scorecard.entity';
 import {
   COST_TYPE_SELECTOR,
@@ -470,6 +472,90 @@ describe('Projects', () => {
       expect(fiveCountriesWithNoGeometry).toEqual(
         expect.arrayContaining(response.body.data),
       );
+    });
+
+    test('Should return projects filter bounds', async () => {
+      const projects: Project[] = [];
+      let it = 0;
+      for (const country of countriesInDb.slice(0, 5)) {
+        it += 1;
+        projects.push(
+          await testManager.mocks().createProject({
+            countryCode: country.code,
+            totalCost: 100 * it,
+            totalCostNPV: 100 * it,
+            abatementPotential: 1000 * it,
+          }),
+        );
+      }
+
+      const response = await testManager
+        .request()
+        .get(projectsContract.getProjectsFiltersBounds.path)
+        .query({
+          filter: {
+            ecosystem: [ECOSYSTEM.MANGROVE, ECOSYSTEM.SEAGRASS],
+            activity: [ACTIVITY.CONSERVATION],
+            projectSizeFilter: [
+              PROJECT_SIZE_FILTER.MEDIUM,
+              PROJECT_SIZE_FILTER.LARGE,
+            ],
+          },
+          costRange: [0, 310_000_000],
+          costRangeSelector: COST_TYPE_SELECTOR.NPV,
+          abatementPotentialRange: [2_000, 3_000],
+          partialProjectName: 'Project',
+        });
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data).toMatchObject({
+        abatementPotential: {
+          max: 3_000,
+          min: 2_000,
+        },
+        cost: {
+          max: 500,
+          min: 100,
+        },
+      });
+    });
+
+    test('Should return projects filter bounds - too strict filtering returns max and min without filters', async () => {
+      const projects: Project[] = [];
+      for (const country of countriesInDb.slice(0, 5)) {
+        projects.push(
+          await testManager
+            .mocks()
+            .createProject({ countryCode: country.code }),
+        );
+      }
+
+      const response = await testManager
+        .request()
+        .get(projectsContract.getProjectsFiltersBounds.path)
+        .query({
+          filter: {
+            ecosystem: [ECOSYSTEM.MANGROVE, ECOSYSTEM.SEAGRASS],
+            activity: [ACTIVITY.CONSERVATION],
+            projectSizeFilter: [PROJECT_SIZE_FILTER.SMALL],
+          },
+          costRange: [0, 310_000_000],
+          costRangeSelector: COST_TYPE_SELECTOR.NPV,
+          abatementPotentialRange: [0, 10_000_000],
+          partialProjectName: 'Project',
+        });
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data).toMatchObject({
+        abatementPotential: {
+          max: 100,
+          min: 100,
+        },
+        cost: {
+          max: 100,
+          min: 100,
+        },
+      });
     });
   });
 

--- a/shared/contracts/projects.contract.ts
+++ b/shared/contracts/projects.contract.ts
@@ -13,6 +13,7 @@ import { ProjectScorecardView } from "@shared/entities/project-scorecard.view";
 import { PaginatedProjectsWithMaximums } from "@shared/dtos/projects/projects.dto";
 import { ProjectScorecardDto } from "@shared/dtos/projects/project-scorecard.dto";
 import { ProjectKeyCosts } from "@shared/dtos/projects/project-key-costs.dto";
+import { ProjectsFiltersBoundsDto } from "@shared/dtos/projects/projects-filters-bounds.dto";
 
 const contract = initContract();
 
@@ -61,6 +62,20 @@ export const projectsContract = contract.router({
       200: contract.type<ApiPaginationResponse<ProjectKeyCosts>>(),
     },
     query: getProjectsQuerySchema,
+  },
+  getProjectsFiltersBounds: {
+    method: "GET",
+    path: "/projects/filters-bounds",
+    responses: {
+      200: contract.type<ApiResponse<ProjectsFiltersBoundsDto>>(),
+    },
+    query: getProjectsQuerySchema.pick({
+      filter: true,
+      costRange: true,
+      abatementPotentialRange: true,
+      costRangeSelector: true,
+      partialProjectName: true,
+    }),
   },
   getProject: {
     method: "GET",

--- a/shared/dtos/projects/projects-filters-bounds.dto.ts
+++ b/shared/dtos/projects/projects-filters-bounds.dto.ts
@@ -1,0 +1,10 @@
+export type ProjectsFiltersBoundsDto = {
+  cost: {
+    min: number;
+    max: number;
+  };
+  abatementPotential: {
+    min: number;
+    max: number;
+  };
+};


### PR DESCRIPTION
## Context
This pull request introduces a new feature to retrieve filter bounds for projects.

- returns the min and max bounds for the cost and abatement potential filters;
- returns the min and max of all projects as defaults if the applied filters are too strict (resulting in empty projects set after filtering)

## Testing
- added integration tests