### PR TITLE
Tbcct 271 be endpoint to retrieve all model assumptions

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -18,6 +18,7 @@ import { CountriesModule } from '@api/modules/countries/countries.module';
 import { ProjectsModule } from '@api/modules/projects/projects.module';
 import { CustomProjectsModule } from '@api/modules/custom-projects/custom-projects.module';
 import { TerminusModule } from '@nestjs/terminus';
+import { MethodologyModule } from '@api/modules/methodology/methodology.module';
 
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -40,6 +41,7 @@ const NODE_ENV = process.env.NODE_ENV;
     UsersModule,
     ProjectsModule,
     CustomProjectsModule,
+    MethodologyModule,
   ],
   controllers: [AppController],
   providers: [

--- a/api/src/modules/methodology/methodology.controller.ts
+++ b/api/src/modules/methodology/methodology.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('methodology')
+export class MethodologyController {}

--- a/api/src/modules/methodology/methodology.controller.ts
+++ b/api/src/modules/methodology/methodology.controller.ts
@@ -1,4 +1,21 @@
-import { Controller } from '@nestjs/common';
+import { Controller, HttpStatus } from '@nestjs/common';
+import { MethodologyService } from '@api/modules/methodology/methodology.service';
+import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
+import { ControllerResponse } from '@api/types/controller-response.type';
+import { methodologyContract } from '@shared/contracts/methodology.contract';
 
-@Controller('methodology')
-export class MethodologyController {}
+@Controller()
+export class MethodologyController {
+  constructor(private readonly methodologyService: MethodologyService) {}
+
+  @TsRestHandler(methodologyContract.getAllModelAssumptions)
+  async getAllModelAssumptions(): Promise<ControllerResponse> {
+    return tsRestHandler(
+      methodologyContract.getAllModelAssumptions,
+      async () => {
+        const data = await this.methodologyService.getAllModelAssumptions();
+        return { body: { data }, status: HttpStatus.OK };
+      },
+    );
+  }
+}

--- a/api/src/modules/methodology/methodology.module.ts
+++ b/api/src/modules/methodology/methodology.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { MethodologyController } from './methodology.controller';
 import { MethodologyService } from './methodology.service';
+import { CalculationsModule } from '@api/modules/calculations/calculations.module';
 
 @Module({
+  imports: [CalculationsModule],
   controllers: [MethodologyController],
-  providers: [MethodologyService]
+  providers: [MethodologyService],
 })
 export class MethodologyModule {}

--- a/api/src/modules/methodology/methodology.module.ts
+++ b/api/src/modules/methodology/methodology.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MethodologyController } from './methodology.controller';
+import { MethodologyService } from './methodology.service';
+
+@Module({
+  controllers: [MethodologyController],
+  providers: [MethodologyService]
+})
+export class MethodologyModule {}

--- a/api/src/modules/methodology/methodology.service.ts
+++ b/api/src/modules/methodology/methodology.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { ModelAssumptions } from '@shared/entities/model-assumptions.entity';
+import { AssumptionsRepository } from '@api/modules/calculations/assumptions.repository';
 
 @Injectable()
-export class MethodologyService {}
+export class MethodologyService {
+  constructor(private readonly assumptionsRepository: AssumptionsRepository) {}
+
+  async getAllModelAssumptions(): Promise<ModelAssumptions[]> {
+    return this.assumptionsRepository.find();
+  }
+}

--- a/api/src/modules/methodology/methodology.service.ts
+++ b/api/src/modules/methodology/methodology.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MethodologyService {}

--- a/api/test/integration/methodology/methodology.spec.ts
+++ b/api/test/integration/methodology/methodology.spec.ts
@@ -1,0 +1,34 @@
+import { TestManager } from '../../utils/test-manager';
+import { methodologyContract } from '@shared/contracts/methodology.contract';
+import { ModelAssumptions } from '@shared/entities/model-assumptions.entity';
+
+describe('Methodology tests', () => {
+  let testManager: TestManager;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager();
+    const { jwtToken } = await testManager.setUpTestUser();
+    await testManager.ingestCountries();
+    await testManager.ingestProjectScoreCards(jwtToken);
+    await testManager.ingestExcel(jwtToken);
+  });
+
+  afterAll(async () => {
+    await testManager.clearDatabase();
+  });
+
+  describe('Model Assumptions', () => {
+    test('Should return all model assumptions', async () => {
+      const modelAssumptions = await testManager
+        .getDataSource()
+        .getRepository(ModelAssumptions)
+        .find();
+      const response = await testManager
+        .request()
+        .get(methodologyContract.getAllModelAssumptions.path)
+        .expect(200);
+
+      expect(response.body.data).toEqual(modelAssumptions);
+    });
+  });
+});

--- a/shared/contracts/index.ts
+++ b/shared/contracts/index.ts
@@ -6,6 +6,7 @@ import { JSONAPIError } from "@shared/dtos/json-api.error";
 import { mapContract } from "@shared/contracts/map.contract";
 import { projectsContract } from "@shared/contracts/projects.contract";
 import { customProjectContract } from "@shared/contracts/custom-projects.contract";
+import {methodologyContract} from "@shared/contracts/methodology.contract";
 
 const contract = initContract();
 
@@ -17,6 +18,7 @@ export const router = contract.router(
     map: mapContract,
     projects: projectsContract,
     customProjects: customProjectContract,
+      methodology: methodologyContract,
   },
   {
     commonResponses: {

--- a/shared/contracts/methodology.contract.ts
+++ b/shared/contracts/methodology.contract.ts
@@ -1,0 +1,19 @@
+import { initContract } from "@ts-rest/core";
+import {
+    ApiResponse,
+} from "@shared/dtos/global/api-response.dto";
+import { ModelAssumptions } from "@shared/entities/model-assumptions.entity";
+
+const contract = initContract();
+export const methodologyContract = contract.router({
+    getAllModelAssumptions: {
+        method: "GET",
+        path: "/methodology/model-assumptions",
+        responses: {
+            200: contract.type<ApiResponse<ModelAssumptions[]>>(),
+        },
+        summary:
+            "Get all model assumptions",
+    },
+});
+


### PR DESCRIPTION
Endpoint to retrieve all model assumptions to be rendered in the methodology sections. Pending to know how can we show the sources


This pull request introduces a new `MethodologyModule` to the project, along with its associated controller, service, and integration tests. Additionally, it updates the contracts to include the new methodology endpoints.

New Module Implementation:

* Added `MethodologyModule` to the imports in `api/src/app.module.ts` and included it in the module's array. [[1]](diffhunk://#diff-1f471e6c80bac8cc219f07df0fcbcb1729f2ec1f035268c30b034c8e687f258eR21) [[2]](diffhunk://#diff-1f471e6c80bac8cc219f07df0fcbcb1729f2ec1f035268c30b034c8e687f258eR44)
* Created `MethodologyController` to handle the new endpoint for fetching all model assumptions.
* Implemented `MethodologyService` to interact with the database and retrieve model assumptions.
* Defined `MethodologyModule` with necessary imports, controllers, and providers.

Contract and Testing Updates:

* Added `methodologyContract` to the shared contracts and defined the endpoint for fetching all model assumptions. [[1]](diffhunk://#diff-856daecb13d10456389759ee000c1254a9da39d4330237815da50e02a84f95a4R1-R19) [[2]](diffhunk://#diff-345a0e7bc9058df7ab16929ef69723ff6003f78113565d95fc96e262672a6535R9) [[3]](diffhunk://#diff-345a0e7bc9058df7ab16929ef69723ff6003f78113565d95fc96e262672a6535R21)
* Created integration tests to validate the new methodology endpoint.