### PR TITLE
fix(api): Remove unneeded env variable validation

### DIFF
--- a/api/src/modules/config/env-config.schema.ts
+++ b/api/src/modules/config/env-config.schema.ts
@@ -11,7 +11,6 @@ const envConfigSchema = z
     DB_USERNAME: z.string(),
     DB_PASSWORD: z.string(),
 
-    API_URL: z.string(),
     ACCESS_TOKEN_SECRET: z.string(),
     ACCESS_TOKEN_EXPIRES_IN: z.string().regex(EXPIRES_IN_REGEX),
 


### PR DESCRIPTION
This pull request includes a small change to the `envConfigSchema` in the `api/src/modules/config/env-config.schema.ts` file. The change removes the `API_URL` configuration parameter.

* [`api/src/modules/config/env-config.schema.ts`](diffhunk://#diff-6797fbb6bfb10a6c1238712e8e0613fff7c75d8e902f3691c3f92251957d2a84L14): Removed the `API_URL` configuration parameter from the `envConfigSchema`.