### PR TITLE
[N/A] consistent "no results" in tables

### DIFF
--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -22,11 +22,11 @@ const ScrollableTable = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <ScrollArea hasHorizontalScroll>
+  <ScrollArea hasHorizontalScroll className="h-full">
     <div className="table h-full w-full table-fixed">
       <table
         ref={ref}
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn("h-full w-full caption-bottom text-sm", className)}
         {...props}
       />
     </div>
@@ -91,7 +91,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-10 bg-big-stone-950 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      "h-10 bg-big-stone-950 px-2 text-left align-middle text-xs font-normal text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
       className,
     )}
     {...props}

--- a/client/src/containers/overview/table/utils.tsx
+++ b/client/src/containers/overview/table/utils.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useState } from "react";
+import { ComponentProps, PropsWithChildren, useState } from "react";
 
 import { Column, SortingState, Updater } from "@tanstack/react-table";
 import { z } from "zod";
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { filtersSchema } from "@/app/(overview)/url-store";
 
 import { scorecardFiltersSchema } from "@/containers/overview/table/view/scorecard-prioritization/schema";
+
+import { TableCell } from "@/components/ui/table";
 
 export const NO_DATA = [];
 
@@ -63,6 +65,12 @@ export const HeaderText = ({ children }: PropsWithChildren) => (
 
 export const CellText = ({ children }: PropsWithChildren) => (
   <span className="text-sm font-normal">{children}</span>
+);
+
+export const NoResults = (props: ComponentProps<typeof TableCell>) => (
+  <TableCell {...props} className="text-center">
+    <div className="flex flex-1 justify-center">No results.</div>
+  </TableCell>
 );
 
 export const getAccessor = <T extends string>(

--- a/client/src/containers/overview/table/view/key-costs/index.tsx
+++ b/client/src/containers/overview/table/view/key-costs/index.tsx
@@ -33,6 +33,7 @@ import {
   filtersToQueryParams,
   getColumnSortTitle,
   NO_DATA,
+  NoResults,
   useSorting,
 } from "@/containers/overview/table/utils";
 import { columns } from "@/containers/overview/table/view/key-costs/columns";
@@ -154,7 +155,7 @@ export function KeyCostsTable() {
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows?.length ? (
+          {isSuccess &&
             table.getRowModel().rows.map((row) => (
               <TableRow
                 className="group cursor-pointer transition-colors hover:bg-big-stone-950"
@@ -187,24 +188,24 @@ export function KeyCostsTable() {
                   </TableCell>
                 ))}
               </TableRow>
-            ))
-          ) : (
+            ))}
+          {isSuccess && data.data.length === 0 && (
             <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
+              <NoResults colSpan={columnsBasedOnFilters.length} />
             </TableRow>
           )}
         </TableBody>
       </ScrollableTable>
-      <TablePagination
-        onChangePagination={setPagination}
-        pagination={{
-          ...pagination,
-          totalPages: data?.metadata?.totalPages ?? 0,
-          totalItems: data?.metadata?.totalItems ?? 0,
-        }}
-      />
+      {isSuccess && data.data.length > 0 && (
+        <TablePagination
+          onChangePagination={setPagination}
+          pagination={{
+            ...pagination,
+            totalPages: data?.metadata?.totalPages ?? 0,
+            totalItems: data?.metadata?.totalItems ?? 0,
+          }}
+        />
+      )}
     </>
   );
 }

--- a/client/src/containers/overview/table/view/overview/index.tsx
+++ b/client/src/containers/overview/table/view/overview/index.tsx
@@ -36,6 +36,7 @@ import {
   filtersToQueryParams,
   getColumnSortTitle,
   NO_DATA,
+  NoResults,
   useSorting,
 } from "@/containers/overview/table/utils";
 import { columns } from "@/containers/overview/table/view/overview/columns";
@@ -188,7 +189,7 @@ export function OverviewTable() {
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows?.length ? (
+          {isSuccess &&
             table.getRowModel().rows.map((row) => (
               <TableRow
                 className="group cursor-pointer transition-colors hover:bg-big-stone-950"
@@ -222,24 +223,26 @@ export function OverviewTable() {
                   </TableCell>
                 ))}
               </TableRow>
-            ))
-          ) : (
+            ))}
+
+          {isSuccess && data.data.length === 0 && (
             <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
+              <NoResults colSpan={columnsBasedOnFilters.length} />
             </TableRow>
           )}
         </TableBody>
       </ScrollableTable>
-      <TablePagination
-        onChangePagination={setPagination}
-        pagination={{
-          ...pagination,
-          totalPages: data?.metadata?.totalPages ?? 0,
-          totalItems: data?.metadata?.totalItems ?? 0,
-        }}
-      />
+
+      {isSuccess && data.data.length > 0 && (
+        <TablePagination
+          onChangePagination={setPagination}
+          pagination={{
+            ...pagination,
+            totalPages: data?.metadata?.totalPages ?? 0,
+            totalItems: data?.metadata?.totalItems ?? 0,
+          }}
+        />
+      )}
     </>
   );
 }

--- a/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
+++ b/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
@@ -34,6 +34,7 @@ import {
   filtersToQueryParams,
   getColumnSortTitle,
   NO_DATA,
+  NoResults,
   useSorting,
 } from "@/containers/overview/table/utils";
 import { TABLE_COLUMNS } from "@/containers/overview/table/view/scorecard-prioritization/columns";
@@ -149,7 +150,7 @@ export function ScoredCardPrioritizationTable() {
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows?.length ? (
+          {isSuccess &&
             table.getRowModel().rows.map((row) => (
               <TableRow
                 key={row.id}
@@ -174,24 +175,25 @@ export function ScoredCardPrioritizationTable() {
                   </TableCell>
                 ))}
               </TableRow>
-            ))
-          ) : (
+            ))}
+
+          {isSuccess && data.data.length === 0 && (
             <TableRow>
-              <TableCell colSpan={TABLE_COLUMNS.length}>
-                <div className="flex flex-1 justify-center">No results.</div>
-              </TableCell>
+              <NoResults colSpan={TABLE_COLUMNS.length} />
             </TableRow>
           )}
         </TableBody>
       </ScrollableTable>
-      <TablePagination
-        onChangePagination={setPagination}
-        pagination={{
-          ...pagination,
-          totalPages: data?.metadata?.totalPages ?? 0,
-          totalItems: data?.metadata?.totalItems ?? 0,
-        }}
-      />
+      {isSuccess && data.data.length > 0 && (
+        <TablePagination
+          onChangePagination={setPagination}
+          pagination={{
+            ...pagination,
+            totalPages: data?.metadata?.totalPages ?? 0,
+            totalItems: data?.metadata?.totalItems ?? 0,
+          }}
+        />
+      )}
       <ProjectDetails />
     </>
   );

--- a/e2e/tests/projects/projects-overview-table.spec.ts
+++ b/e2e/tests/projects/projects-overview-table.spec.ts
@@ -1,6 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
 import { E2eTestManager } from "@shared/lib/e2e-test-manager";
-import { User } from "@shared/entities/users/user.entity";
 import {Country} from "@shared/entities/country.entity";
 import {Project, PROJECT_PRICE_TYPE} from "@shared/entities/projects.entity";
 import {PROJECT_OVERVIEW_TABLE_LOCATOR} from "../../page-objects";
@@ -32,7 +31,8 @@ test.describe("Projects - Overview Table", () => {
             await testManager.mocks().createProject({countryCode: china.code, projectName: `${priceType} China Mangrove Conservation`, priceType});
             await testManager.mocks().createProject({countryCode: india.code, projectName: `${priceType} India Mangrove Conservation`, priceType});
         }
-        await page.goto('http://localhost:3000/');
+        page.goto('http://localhost:3000/');
+        await page.waitForResponse('**/projects?**');
         const firstRowCellsBeforeFilter = await page.locator(PROJECT_OVERVIEW_TABLE_LOCATOR).nth(0).locator('td').allTextContents();
         expect(firstRowCellsBeforeFilter).toContain(`Market price China Mangrove Conservation`)
         await page.locator('button').filter({ hasText: 'Market price' }).click();


### PR DESCRIPTION
This pull request includes several changes to the table components and their usage in various parts of the application. The main focus is on improving the table's appearance and functionality, as well as adding new utility components for better code reuse.

![image](https://github.com/user-attachments/assets/b44e7bb4-3387-4551-8fce-a74b635637e7)

Improvements to table components:

* [`client/src/components/ui/table.tsx`](diffhunk://#diff-8fb400981d306228d89c48b0fc071e12e28b02b56fbf40856c54e48c1bd0967aL25-R29): Modified the `ScrollableTable` and `TableHead` components to ensure the table takes full height and adjusted the table head styles. [[1]](diffhunk://#diff-8fb400981d306228d89c48b0fc071e12e28b02b56fbf40856c54e48c1bd0967aL25-R29) [[2]](diffhunk://#diff-8fb400981d306228d89c48b0fc071e12e28b02b56fbf40856c54e48c1bd0967aL94-R94)

Enhancements to table utilities:

* [`client/src/containers/overview/table/utils.tsx`](diffhunk://#diff-869d264af54f2ba2c5854e64d53e6d445a5ba08a2741eadcd3ea421ec5f463dbL1-R1): Added `ComponentProps` import and introduced a new `NoResults` component for displaying a "No results" message in tables. [[1]](diffhunk://#diff-869d264af54f2ba2c5854e64d53e6d445a5ba08a2741eadcd3ea421ec5f463dbL1-R1) [[2]](diffhunk://#diff-869d264af54f2ba2c5854e64d53e6d445a5ba08a2741eadcd3ea421ec5f463dbR10-R11) [[3]](diffhunk://#diff-869d264af54f2ba2c5854e64d53e6d445a5ba08a2741eadcd3ea421ec5f463dbR70-R75)

Updates to table usage in views:

* [`client/src/containers/overview/table/view/key-costs/index.tsx`](diffhunk://#diff-dfdd1ccddd5007c43db2bf0a58e1445909c68f9c2ca6638d963af5e11a45e3a1R36): Utilized the new `NoResults` component and added conditional rendering based on `isSuccess` and data length. [[1]](diffhunk://#diff-dfdd1ccddd5007c43db2bf0a58e1445909c68f9c2ca6638d963af5e11a45e3a1R36) [[2]](diffhunk://#diff-dfdd1ccddd5007c43db2bf0a58e1445909c68f9c2ca6638d963af5e11a45e3a1L157-R158) [[3]](diffhunk://#diff-dfdd1ccddd5007c43db2bf0a58e1445909c68f9c2ca6638d963af5e11a45e3a1L190-R199) [[4]](diffhunk://#diff-dfdd1ccddd5007c43db2bf0a58e1445909c68f9c2ca6638d963af5e11a45e3a1R208)
* [`client/src/containers/overview/table/view/overview/index.tsx`](diffhunk://#diff-339c959a187f5c046ce8f898d6cbbba8472dcf35ab017aec7924615e5eee5dfeR39): Applied similar updates as in `key-costs` view for consistency. [[1]](diffhunk://#diff-339c959a187f5c046ce8f898d6cbbba8472dcf35ab017aec7924615e5eee5dfeR39) [[2]](diffhunk://#diff-339c959a187f5c046ce8f898d6cbbba8472dcf35ab017aec7924615e5eee5dfeL191-R192) [[3]](diffhunk://#diff-339c959a187f5c046ce8f898d6cbbba8472dcf35ab017aec7924615e5eee5dfeL225-R236) [[4]](diffhunk://#diff-339c959a187f5c046ce8f898d6cbbba8472dcf35ab017aec7924615e5eee5dfeR245)
* [`client/src/containers/overview/table/view/scorecard-prioritization/index.tsx`](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R37): Incorporated the `NoResults` component and updated conditional rendering logic. [[1]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R37) [[2]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072L152-R153) [[3]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072L177-R187) [[4]](diffhunk://#diff-bfda56ea32fe24a32f96278c9094684ecab2b166f83dd583aeb295e0dd7bf072R196)

Minor adjustments:

* [`e2e/tests/projects/projects-overview-table.spec.ts`](diffhunk://#diff-4b07e3a3b7383972f20ec23766714e96b4b61c8926022fa570a5ba9cf4efbdbbL3): Removed unused import and added a wait for the response in the test setup. [[1]](diffhunk://#diff-4b07e3a3b7383972f20ec23766714e96b4b61c8926022fa570a5ba9cf4efbdbbL3) [[2]](diffhunk://#diff-4b07e3a3b7383972f20ec23766714e96b4b61c8926022fa570a5ba9cf4efbdbbL35-R35)
