### PR TITLE
[TBCCT-278] fix(api): Remove 0 year from all cost plans

### DIFF
--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -431,6 +431,8 @@ export class CostCalculator {
       const plan = costPlans[planName];
       normalizedCostPlans[planName] = {};
       for (let year = startYear; year <= endYear; year++) {
+        if (year === 0) continue;
+
         normalizedCostPlans[planName][year] = plan[year] || 0;
       }
     }

--- a/api/test/integration/custom-projects/custom-projects-create.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-create.spec.ts
@@ -67,18 +67,22 @@ describe('Create Custom Projects - Setup', () => {
             emissionFactorSOC: 0,
           },
         });
-      expect(response.status).toBe(201);
 
-      expect(response.body.data.totalCostNPV).toEqual(3619506.2162071504);
-      expect(response.body.data.totalCost).toEqual(5556541.947938656);
-      expect(response.body.data.breakevenTotalCost).toEqual(3750308.289753845);
-      expect(response.body.data.breakevenTotalCostNPV).toEqual(
-        2667356.215719252,
+      expect(response.status).toBe(201);
+      const responseData = response.body.data;
+      expect(responseData.totalCostNPV).toEqual(3619506.2162071504);
+      expect(responseData.totalCost).toEqual(5556541.947938656);
+      expect(responseData.breakevenTotalCost).toEqual(3750308.289753845);
+      expect(responseData.breakevenTotalCostNPV).toEqual(2667356.215719252);
+      const output = responseData.output;
+      expect(output.breakevenPriceComputationOutput.initialCarbonPrice).toEqual(
+        11.94909091180203,
       );
-      expect(
-        response.body.data.output.breakevenPriceComputationOutput
-          .initialCarbonPrice,
-      ).toEqual(11.94909091180203);
+      const yearlyBreakdown =
+        output.initialCarbonPriceComputationOutput.yearlyBreakdown;
+      for (const breakdown of yearlyBreakdown) {
+        expect(breakdown[0]).toBeUndefined();
+      }
     });
   });
 });


### PR DESCRIPTION
This pull request includes changes to the `CostCalculator` class to handle edge cases and improvements to the test cases for custom projects. The most important changes include adding a condition to skip processing for year 0 in the `CostCalculator` and refactoring test assertions for better readability and maintainability.

Changes to handle edge cases:

* [`api/src/modules/calculations/cost.calculator.ts`](diffhunk://#diff-f3a786faa816de52227b70d447bbed13537c00886ffc27518b616149b4a2e4d7R434-R435): Added a condition to skip processing for year 0 in the `CostCalculator` class.

Improvements to test cases:

* [`api/test/integration/custom-projects/custom-projects-create.spec.ts`](diffhunk://#diff-bfc98e374a31af4eb816dadb67f4cab3fa008a3984df106cce20aca6e9f74888L70-R85): Refactored test assertions to use a local variable for `response.body.data` and added checks for `output.breakevenPriceComputationOutput.initialCarbonPrice` and `output.initialCarbonPriceComputationOutput.yearlyBreakdown`.