### PR TITLE
fix: ecosystem radiobox selection + update label

### DIFF
--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/utils.ts
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/utils.ts
@@ -115,7 +115,7 @@ const cashflowConfig: Record<YearlyBreakdownCostName, CostNameConfig> = {
   },
   communityBenefitSharingFund: {
     order: 12,
-    label: "Community benefit sharing fund",
+    label: "Landowner/community benefit share",
   },
   carbonStandardFees: {
     order: 13,

--- a/client/src/containers/projects/custom-project/cost-details/table/utils.ts
+++ b/client/src/containers/projects/custom-project/cost-details/table/utils.ts
@@ -20,7 +20,7 @@ const customProjectCostDetailsLabelMap: Record<
   operationalExpenditure: "Operating expenditure",
   monitoring: "Monitoring",
   maintenance: "Maintenance",
-  communityBenefitSharingFund: "Community benefit sharing fund",
+  communityBenefitSharingFund: "Landowner/community benefit share",
   carbonStandardFees: "Carbon standard fees",
   baselineReassessment: "Baseline reassessment",
   mrv: "MRV",

--- a/client/src/containers/projects/form/setup/index.tsx
+++ b/client/src/containers/projects/form/setup/index.tsx
@@ -232,7 +232,7 @@ export default function SetupProjectForm() {
                   <FormControl>
                     <RadioGroup
                       className="flex gap-4"
-                      defaultValue={form.getValues("ecosystem") as ECOSYSTEM}
+                      value={form.getValues("ecosystem") as ECOSYSTEM}
                       onValueChange={async (v) => {
                         form.setValue("ecosystem", v as ECOSYSTEM);
                         await form.trigger("ecosystem");

--- a/shared/schemas/assumptions/assumptions.enums.ts
+++ b/shared/schemas/assumptions/assumptions.enums.ts
@@ -54,7 +54,7 @@ export const COSTS_DTO_MAP = {
   monitoring: { label: "Monitoring", unit: "$/yr" },
   maintenance: { label: "Maintenance", unit: "%" },
   communityBenefitSharingFund: {
-    label: "Community benefit sharing fund",
+    label: "Landowner/community benefit share",
     unit: "%",
   },
   carbonStandardFees: { label: "Carbon standard fees", unit: "$/credit" },


### PR DESCRIPTION
## Label Update and Radio Group Fix

## Changes
- Updated "Community benefit sharing fund" label to "Landowner/community benefit share"
- Fixed radio group in project setup form to use controlled `value` prop instead of `defaultValue`

## Figma
- [TBCCT-285](https://vizzuality.atlassian.net/browse/TBCCT-285)

[TBCCT-285]: https://vizzuality.atlassian.net/browse/TBCCT-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ