### PR TITLE
[N/A] makes sure projectSpecificLossRate is valid when switching to nationa…

### DIFF
--- a/client/src/containers/projects/form/setup/conservation-project-details/index.tsx
+++ b/client/src/containers/projects/form/setup/conservation-project-details/index.tsx
@@ -69,6 +69,18 @@ export default function ConservationProjectDetails() {
                       "parameters.lossRateUsed",
                       v as LOSS_RATE_USED,
                     );
+                    if (v === LOSS_RATE_USED.NATIONAL_AVERAGE) {
+                      form.setValue(
+                        "parameters.projectSpecificLossRate",
+                        // prettier-ignore
+                        form.getFieldState("parameters.projectSpecificLossRate").invalid ?
+                            // @ts-expect-error fix later
+                            form.formState.defaultValues?.parameters?.projectSpecificLossRate
+                            // @ts-expect-error fix later
+                          : form.getValues().parameters?.projectSpecificLossRate,
+                      );
+                      await form.trigger("parameters.projectSpecificLossRate");
+                    }
                     await form.trigger("parameters.lossRateUsed");
                   }}
                 >


### PR DESCRIPTION
This PR fixes an issue where the user was unable to submit the custom project when an incorrect value was set for the Project-specific loss rate and then the loss rate was set to National (hiding the Project-specific loss rate but still invalid).

The fix makes sure the Project-specific loss rate is always valid via:
- if the user set a valid input before switching to National loss rate, we will keep it once back to it.
- if the user set an invalid input before switching to National loss rate, we will revert it to the default value of the form.

Jira: N/A