### PR TITLE
Use initial carbon price assumption

### DIFF
--- a/api/src/modules/custom-projects/custom-projects.service.ts
+++ b/api/src/modules/custom-projects/custom-projects.service.ts
@@ -63,6 +63,9 @@ export class CustomProjectsService extends AppBaseService<
       ecosystem,
       activity,
     });
+    if (dto.initialCarbonPriceAssumption) {
+      additionalAssumptions.carbonPrice = dto.initialCarbonPriceAssumption;
+    }
 
     const projectInput = this.customProjectFactory.createProjectInput(
       dto,

--- a/api/test/integration/custom-projects/custom-projects-create.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-create.spec.ts
@@ -70,8 +70,8 @@ describe('Create Custom Projects - Setup', () => {
 
       expect(response.status).toBe(201);
       const responseData = response.body.data;
-      expect(responseData.totalCostNPV).toEqual(3619506.2162071504);
-      expect(responseData.totalCost).toEqual(5556541.947938656);
+      expect(responseData.totalCostNPV).toEqual(3092025.8572758473);
+      expect(responseData.totalCost).toEqual(4555908.877681957);
       expect(responseData.breakevenTotalCost).toEqual(3750308.289753845);
       expect(responseData.breakevenTotalCostNPV).toEqual(2667356.215719252);
       const output = responseData.output;
@@ -83,6 +83,10 @@ describe('Create Custom Projects - Setup', () => {
       for (const breakdown of yearlyBreakdown) {
         expect(breakdown.costValues[0]).toBeUndefined();
       }
+      expect(
+        responseData.output.initialCarbonPriceComputationOutput
+          .initialCarbonPrice,
+      ).toEqual(20);
     });
   });
 });


### PR DESCRIPTION
This pull request includes several changes to the `custom-projects` module, specifically adding a new assumption for carbon price and updating related tests. The most important changes are:

### Custom Projects Service Update:

* [`api/src/modules/custom-projects/custom-projects.service.ts`](diffhunk://#diff-a450b42f83aa743e906c235e1dbcc649854328c6951985e9bcaf6a40b6029eacR66-R68): Added a check to include `initialCarbonPriceAssumption` in `additionalAssumptions` if it is provided in the DTO.

### Integration Tests Update:

* [`api/test/integration/custom-projects/custom-projects-create.spec.ts`](diffhunk://#diff-bfc98e374a31af4eb816dadb67f4cab3fa008a3984df106cce20aca6e9f74888L73-R74): Updated the expected values for `totalCostNPV` and `totalCost` in the integration tests to reflect the changes in the service logic.
* [`api/test/integration/custom-projects/custom-projects-create.spec.ts`](diffhunk://#diff-bfc98e374a31af4eb816dadb67f4cab3fa008a3984df106cce20aca6e9f74888R86-R89): Added a new expectation to check the value of `initialCarbonPrice` in the `initialCarbonPriceComputationOutput` of the response data.