### PR TITLE
refactor: remove user joins from custom project queries

### DIFF
--- a/api/src/modules/custom-projects/custom-projects.service.ts
+++ b/api/src/modules/custom-projects/custom-projects.service.ts
@@ -132,9 +132,7 @@ export class CustomProjectsService extends AppBaseService<
   ): Promise<SelectQueryBuilder<CustomProject>> {
     const { user } = info;
 
-    query
-      .leftJoinAndSelect('customProject.user', 'user')
-      .andWhere('user.id = :userId', { userId: user.id });
+    query.andWhere('customProject.user_id = :userId', { userId: user.id });
 
     return query;
   }
@@ -146,9 +144,7 @@ export class CustomProjectsService extends AppBaseService<
   ): Promise<SelectQueryBuilder<CustomProject>> {
     const { user } = info;
 
-    query
-      .leftJoinAndSelect('customProject.user', 'user')
-      .andWhere('user.id = :userId', { userId: user.id });
+    query.andWhere('customProject.user_id = :userId', { userId: user.id });
 
     if (fetchSpecification.partialProjectName) {
       query = query.andWhere('project_name ILIKE :projectName', {

--- a/api/test/integration/custom-projects/custom-projects-read.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-read.spec.ts
@@ -84,6 +84,9 @@ describe('Read Custom projects', () => {
       // Then
       expect(response.status).toBe(200);
       expect(response.body.data.id).toBe(customProject.id);
+      const customProjectData = response.body.data as CustomProject;
+      expect(response.body.data).toEqual(customProjectData);
+      expect(response.body.data.user).toBeUndefined();
     });
 
     test('An authenticated user should be able to retrieve its custom projects', async () => {

--- a/shared/entities/custom-project.entity.ts
+++ b/shared/entities/custom-project.entity.ts
@@ -62,7 +62,6 @@ export class CustomProject {
 
   @ManyToOne(() => User, (user) => user.customProjects, {
     onDelete: "CASCADE",
-    eager: true,
   })
   @JoinColumn({ name: "user_id" })
   user?: User;


### PR DESCRIPTION
## Remove User Joins from Custom Project Queries

### What does this PR do?
Removes unnecessary user joins from custom project queries. This change prevents user data from being included in API responses, improving data privacy.

### Changes
- Removed `leftJoinAndSelect` for user data in `extendGetByIdQuery`
- Removed `leftJoinAndSelect` for user data in `extendFindAllQuery`
- Updated where clauses to use `customProject.user_id` directly

### Why?
Previously, we were unnecessarily including user data in our query results and API responses. This change improves data privacy by only returning the essential custom project data.
