### PR TITLE
[TBCCT-312] defaults restoration activity to make sure costs are calculated

### DIFF
--- a/client/src/containers/projects/form/cost-inputs-overrides/capex/index.tsx
+++ b/client/src/containers/projects/form/cost-inputs-overrides/capex/index.tsx
@@ -1,5 +1,3 @@
-import { useFormContext } from "react-hook-form";
-
 import { ACTIVITY } from "@shared/entities/activity.enum";
 import { COSTS_DTO_MAP } from "@shared/schemas/assumptions/assumptions.enums";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
@@ -15,14 +13,12 @@ import {
   COST_INPUTS_KEYS,
   DataColumnDef,
 } from "@/containers/projects/form/cost-inputs-overrides/constants";
-import { CustomProjectForm } from "@/containers/projects/form/setup";
+import { useFormValues } from "@/containers/projects/form/project-form";
 import FormTable from "@/containers/projects/form/table";
 
 const NO_DATA: DataColumnDef<CapexFormProperty>[] = [];
 
 export default function CapexCostInputsTable() {
-  const form = useFormContext<CustomProjectForm>();
-
   const {
     ecosystem,
     countryCode,
@@ -31,7 +27,7 @@ export default function CapexCostInputsTable() {
       // @ts-expect-error fix later
       restorationActivity,
     },
-  } = form.getValues();
+  } = useFormValues();
 
   const { queryKey } = queryKeys.customProjects.defaultCosts({
     ecosystem,

--- a/client/src/containers/projects/form/cost-inputs-overrides/opex/index.tsx
+++ b/client/src/containers/projects/form/cost-inputs-overrides/opex/index.tsx
@@ -1,5 +1,3 @@
-import { useFormContext } from "react-hook-form";
-
 import { ACTIVITY } from "@shared/entities/activity.enum";
 import { COSTS_DTO_MAP } from "@shared/schemas/assumptions/assumptions.enums";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
@@ -15,14 +13,12 @@ import {
   COLUMNS,
   OpexFormProperty,
 } from "@/containers/projects/form/cost-inputs-overrides/opex/columns";
-import { CustomProjectForm } from "@/containers/projects/form/setup";
+import { useFormValues } from "@/containers/projects/form/project-form";
 import FormTable from "@/containers/projects/form/table";
 
 const NO_DATA: DataColumnDef<OpexFormProperty>[] = [];
 
 export default function OpexCostInputsTable() {
-  const form = useFormContext<CustomProjectForm>();
-
   const {
     ecosystem,
     countryCode,
@@ -31,7 +27,7 @@ export default function OpexCostInputsTable() {
       // @ts-expect-error fix later
       restorationActivity,
     },
-  } = form.getValues();
+  } = useFormValues();
 
   const { queryKey } = queryKeys.customProjects.defaultCosts({
     ecosystem,

--- a/client/src/containers/projects/form/cost-inputs-overrides/other/index.tsx
+++ b/client/src/containers/projects/form/cost-inputs-overrides/other/index.tsx
@@ -1,5 +1,3 @@
-import { useFormContext } from "react-hook-form";
-
 import { ACTIVITY } from "@shared/entities/activity.enum";
 import { COSTS_DTO_MAP } from "@shared/schemas/assumptions/assumptions.enums";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
@@ -15,14 +13,12 @@ import {
   COLUMNS,
   OtherFormProperty,
 } from "@/containers/projects/form/cost-inputs-overrides/other/columns";
-import { CustomProjectForm } from "@/containers/projects/form/setup";
+import { useFormValues } from "@/containers/projects/form/project-form";
 import FormTable from "@/containers/projects/form/table";
 
 const NO_DATA: DataColumnDef<OtherFormProperty>[] = [];
 
 export default function OtherCostInputsTable() {
-  const form = useFormContext<CustomProjectForm>();
-
   const {
     ecosystem,
     countryCode,
@@ -31,7 +27,7 @@ export default function OtherCostInputsTable() {
       // @ts-expect-error fix later
       restorationActivity,
     },
-  } = form.getValues();
+  } = useFormValues();
 
   const { queryKey } = queryKeys.customProjects.defaultCosts({
     ecosystem,

--- a/client/src/containers/projects/form/setup/index.tsx
+++ b/client/src/containers/projects/form/setup/index.tsx
@@ -19,6 +19,7 @@ import { client } from "@/lib/query-client";
 import { queryKeys } from "@/lib/query-keys";
 
 import { ACTIVITIES } from "@/containers/overview/filters/constants";
+import { useFormValues } from "@/containers/projects/form/project-form";
 import ConservationProjectDetails from "@/containers/projects/form/setup/conservation-project-details";
 import { CARBON_REVENUES_TO_COVER_DESCRIPTIONS } from "@/containers/projects/form/setup/constants";
 import RestorationProjectDetails from "@/containers/projects/form/setup/restoration-project-detail";
@@ -67,7 +68,7 @@ export default function SetupProjectForm() {
     activity,
     // @ts-expect-error fix later
     parameters: { emissionFactorUsed, tierSelector, restorationActivity },
-  } = form.getValues();
+  } = useFormValues();
 
   const isDisabled = (ecosystem: ECOSYSTEM) => {
     if (activity === ACTIVITY.CONSERVATION) {
@@ -299,10 +300,16 @@ export default function SetupProjectForm() {
                         form.setValue("activity", v as ACTIVITY);
                         await form.trigger("activity");
 
-                        // form.setValue(
-                        //   "parameters.restorationActivity",
-                        //   RESTORATION_ACTIVITY_SUBTYPE.HYBRID,
-                        // );
+                        // ? we default to a restoration activity ensuring costs are always calculated
+                        if (
+                          v === ACTIVITY.RESTORATION &&
+                          !restorationActivity
+                        ) {
+                          form.setValue(
+                            "parameters.restorationActivity",
+                            RESTORATION_ACTIVITY_SUBTYPE.HYBRID,
+                          );
+                        }
                       }}
                     >
                       {ACTIVITIES.map((activity) => (


### PR DESCRIPTION
This pull request includes changes to refactor the form handling in multiple components to use the `useFormValues` hook instead of `useFormContext`. This change aims to streamline the code and improve consistency across the project.

Refactoring form handling:

* [`client/src/containers/projects/form/cost-inputs-overrides/capex/index.tsx`](diffhunk://#diff-dfaabd9ecb243e346ab21fb26426590bd1b058a4484287a8709b959d071bc33eL1-L2): Replaced `useFormContext` with `useFormValues` for retrieving form values in `CapexCostInputsTable`. [[1]](diffhunk://#diff-dfaabd9ecb243e346ab21fb26426590bd1b058a4484287a8709b959d071bc33eL1-L2) [[2]](diffhunk://#diff-dfaabd9ecb243e346ab21fb26426590bd1b058a4484287a8709b959d071bc33eL22-R20) [[3]](diffhunk://#diff-dfaabd9ecb243e346ab21fb26426590bd1b058a4484287a8709b959d071bc33eL36-L37) [[4]](diffhunk://#diff-dfaabd9ecb243e346ab21fb26426590bd1b058a4484287a8709b959d071bc33eL46-R42)
* [`client/src/containers/projects/form/cost-inputs-overrides/opex/index.tsx`](diffhunk://#diff-bb4acc403173fc5e546ca0ca102bfd7e139d356569ae22d8a5208514f5f01f7aL1-L2): Replaced `useFormContext` with `useFormValues` for retrieving form values in `OpexCostInputsTable`. [[1]](diffhunk://#diff-bb4acc403173fc5e546ca0ca102bfd7e139d356569ae22d8a5208514f5f01f7aL1-L2) [[2]](diffhunk://#diff-bb4acc403173fc5e546ca0ca102bfd7e139d356569ae22d8a5208514f5f01f7aL22-R20) [[3]](diffhunk://#diff-bb4acc403173fc5e546ca0ca102bfd7e139d356569ae22d8a5208514f5f01f7aL36-L37) [[4]](diffhunk://#diff-bb4acc403173fc5e546ca0ca102bfd7e139d356569ae22d8a5208514f5f01f7aL46-R42)
* [`client/src/containers/projects/form/cost-inputs-overrides/other/index.tsx`](diffhunk://#diff-bccf2715dc0126b15290b6df8365d13d12d52d667a5c389988ce709cc681f003L1-L2): Replaced `useFormContext` with `useFormValues` for retrieving form values in `OtherCostInputsTable`. [[1]](diffhunk://#diff-bccf2715dc0126b15290b6df8365d13d12d52d667a5c389988ce709cc681f003L1-L2) [[2]](diffhunk://#diff-bccf2715dc0126b15290b6df8365d13d12d52d667a5c389988ce709cc681f003L22-R20) [[3]](diffhunk://#diff-bccf2715dc0126b15290b6df8365d13d12d52d667a5c389988ce709cc681f003L36-L37) [[4]](diffhunk://#diff-bccf2715dc0126b15290b6df8365d13d12d52d667a5c389988ce709cc681f003L46-R42)
* [`client/src/containers/projects/form/setup/index.tsx`](diffhunk://#diff-76ff671b13f64fd40605c706978877d5bf05877de2cfe7315069a9b71f8c7becR22): Replaced `useFormContext` with `useFormValues` for retrieving form values in `SetupProjectForm`, and added a conditional default setting for `restorationActivity`. [[1]](diffhunk://#diff-76ff671b13f64fd40605c706978877d5bf05877de2cfe7315069a9b71f8c7becR22) [[2]](diffhunk://#diff-76ff671b13f64fd40605c706978877d5bf05877de2cfe7315069a9b71f8c7becL70-R71) [[3]](diffhunk://#diff-76ff671b13f64fd40605c706978877d5bf05877de2cfe7315069a9b71f8c7becL302-R312)

Jira: https://vizzuality.atlassian.net/browse/TBCCT-312
