### PR TITLE
[TBCCT-312?] harmonizes countries fetching in custom project form

### DIFF
--- a/client/src/containers/projects/form/setup/index.tsx
+++ b/client/src/containers/projects/form/setup/index.tsx
@@ -51,16 +51,20 @@ import {
 export type CustomProjectForm = z.infer<typeof CreateCustomProjectSchema>;
 
 export default function SetupProjectForm() {
-  const { queryKey } = queryKeys.countries.all;
-  const { data: countryOptions } = client.projects.getProjectCountries.useQuery(
-    queryKey,
-    {},
-    {
+  const { queryKey } = queryKeys.customProjects.countries;
+  const { data: countryOptions } =
+    client.customProjects.getAvailableCountries.useQuery(
       queryKey,
-      select: (data) =>
-        data.body.data.map(({ name, code }) => ({ label: name, value: code })),
-    },
-  );
+      {},
+      {
+        queryKey,
+        select: (data) =>
+          data.body.data.map(({ name, code }) => ({
+            label: name,
+            value: code,
+          })),
+      },
+    );
 
   const form = useFormContext<CustomProjectForm>();
 


### PR DESCRIPTION
**NOTE: we need BE to restore one of the tables in the database to ensure this change works.**

This pull request includes a change to the `SetupProjectForm` component in `client/src/containers/projects/form/setup/index.tsx`. The change updates the query key and the method used to retrieve country options for custom projects.

Changes to `SetupProjectForm` component:

* Updated the query key from `queryKeys.countries.all` to `queryKeys.customProjects.countries`.
* Changed the method used to retrieve country options from `client.projects.getProjectCountries.useQuery` to `client.customProjects.getAvailableCountries.useQuery`.
* Reformatted the mapping function to improve readability.



Related to: https://vizzuality.atlassian.net/browse/TBCCT-312