### PR TITLE
fix/backoffice-image-build

### DIFF
--- a/backoffice/Dockerfile
+++ b/backoffice/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.11.0-alpine
+FROM node:22.2.0-alpine
 
 ARG DB_HOST
 ARG DB_PORT


### PR DESCRIPTION
This pull request includes a change to the `backoffice/Dockerfile` to update the Node.js version used in the Docker image.

* [`backoffice/Dockerfile`](diffhunk://#diff-3a69359014bad304dd392c6ed50846366af14e2df08400e72e0478c12db84d61L1-R1): Updated the Node.js version from `22.11.0-alpine` to `22.2.0-alpine`.