### PR TITLE
feat(api): Add initial carbon price default value in the /assumptions endpoint

### DIFF
--- a/api/test/integration/calculations/fixtures/restoration-mexico-mangroves.ts
+++ b/api/test/integration/calculations/fixtures/restoration-mexico-mangroves.ts
@@ -1,5 +1,5 @@
-import { CreateCustomProjectDto } from '@api/modules/custom-projects/dto/create-custom-project.dto';
 import { RestorationProjectInput } from '@api/modules/custom-projects/input-factory/restoration-project.input';
+import { CreateCustomProjectDto } from '@shared/dtos/custom-projects/create-custom-project.dto';
 
 /**
  * Input received in the endpoint

--- a/api/test/integration/custom-projects/custom-projects-setup.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-setup.spec.ts
@@ -48,11 +48,12 @@ describe('Create Custom Projects - Setup', () => {
           activity: ACTIVITY.CONSERVATION,
         });
 
-      expect(response.body.data).toHaveLength(7);
+      expect(response.body.data).toHaveLength(8);
       expect(response.body.data.map((assumptions) => assumptions.name)).toEqual(
         [
           'Baseline reassessment frequency',
           'Buffer',
+          'Carbon price',
           'Carbon price increase',
           'Conservation project length',
           'Discount rate',

--- a/shared/schemas/assumptions/assumptions.enums.ts
+++ b/shared/schemas/assumptions/assumptions.enums.ts
@@ -12,6 +12,7 @@ export enum ACTIVITY_PROJECT_LENGTH_NAMES {
 export const COMMON_OVERRIDABLE_ASSUMPTION_NAMES = [
   "Baseline reassessment frequency",
   "Buffer",
+  "Carbon price",
   "Carbon price increase",
   "Discount rate",
   "Verification frequency",


### PR DESCRIPTION
This pull request includes updates to the custom projects setup and assumptions enums to include a new assumption, "Carbon price."

Changes to custom projects setup:

* [`api/test/integration/custom-projects/custom-projects-setup.spec.ts`](diffhunk://#diff-b91e7fa38b414665b5837150fd1bf381a04a1affd5a12b2835fc7edc6ef8cff3L51-R56): Modified the test expectation to account for the new "Carbon price" assumption, increasing the expected data length from 7 to 8.

Changes to assumptions enums:

* [`shared/schemas/assumptions/assumptions.enums.ts`](diffhunk://#diff-60224e7ca44abce666ca7a85d22f45d8e2c58fac26deb601ab487853e4b8c032R15): Added "Carbon price" to the list of common overridable assumption names.