### PR TITLE
Add Breakeven Point and Revenue Coverage to Cash Flow Chart

### DIFF
--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
@@ -2,6 +2,7 @@
 
 import { FC } from "react";
 
+import { CARBON_REVENUES_TO_COVER } from "@shared/entities/custom-project.entity";
 import {
   Bar,
   CartesianGrid,
@@ -13,7 +14,11 @@ import {
 
 import { formatCurrency } from "@/lib/format";
 
-import { YearlyBreakdownChartData } from "@/containers/projects/custom-project/annual-project-cash-flow/utils";
+import {
+  YearlyBreakdownChartData,
+  cumulativeNetIncomePlanTooltipLabel,
+} from "@/containers/projects/custom-project/annual-project-cash-flow/utils";
+import { cashflowConfig } from "@/containers/projects/custom-project/annual-project-cash-flow/utils";
 
 import {
   ChartContainer,
@@ -33,9 +38,13 @@ const CHART_COLORS = {
 
 interface CashflowChartProps {
   data: YearlyBreakdownChartData;
+  carbonRevenuesToCover?: CARBON_REVENUES_TO_COVER;
 }
 
-const CashflowChart: FC<CashflowChartProps> = ({ data }) => {
+const CashflowChart: FC<CashflowChartProps> = ({
+  data,
+  carbonRevenuesToCover,
+}) => {
   return (
     <ChartContainer
       config={{
@@ -57,7 +66,10 @@ const CashflowChart: FC<CashflowChartProps> = ({ data }) => {
           icon: () => <div className="h-[3px] w-[24px] bg-chart-4" />,
         },
         cumulativeNetIncomePlan: {
-          label: "Revenue OpEx",
+          label:
+            cumulativeNetIncomePlanTooltipLabel[
+              carbonRevenuesToCover as keyof typeof cumulativeNetIncomePlanTooltipLabel
+            ],
           color: "hsl(var(--chart-5))",
           icon: () => <div className="h-[3px] w-[24px] bg-chart-5" />,
         },
@@ -151,9 +163,17 @@ const CashflowChart: FC<CashflowChartProps> = ({ data }) => {
               indicator="dot"
               className="border-border"
               formatter={(v, n) => {
+                const config = cashflowConfig[n as keyof typeof cashflowConfig];
+                let label = config.label;
+                if (n === "cumulativeNetIncomePlan") {
+                  label =
+                    cumulativeNetIncomePlanTooltipLabel[
+                      carbonRevenuesToCover as keyof typeof cumulativeNetIncomePlanTooltipLabel
+                    ];
+                }
                 return (
                   <p className="inline-flex w-full justify-between gap-2">
-                    <span className="text-muted-foreground">{n}</span>
+                    <span className="text-muted-foreground">{label}</span>
                     <span className="font-normal">
                       {formatCurrency(v as number, {
                         maximumFractionDigits: 0,

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
@@ -10,6 +10,7 @@ import {
   Line,
   XAxis,
   YAxis,
+  ReferenceLine,
 } from "recharts";
 
 import { formatCurrency } from "@/lib/format";
@@ -38,11 +39,13 @@ const CHART_COLORS = {
 
 interface CashflowChartProps {
   data: YearlyBreakdownChartData;
+  breakevenPoint: number | null;
   carbonRevenuesToCover?: CARBON_REVENUES_TO_COVER;
 }
 
 const CashflowChart: FC<CashflowChartProps> = ({
   data,
+  breakevenPoint,
   carbonRevenuesToCover,
 }) => {
   return (
@@ -73,6 +76,11 @@ const CashflowChart: FC<CashflowChartProps> = ({
           color: "hsl(var(--chart-5))",
           icon: () => <div className="h-[3px] w-[24px] bg-chart-5" />,
         },
+        breakevenPoint: {
+          label: "Breakeven point",
+          color: "hsl(var(--destructive))",
+          icon: () => <div className="h-[3px] w-[24px] bg-destructive" />,
+        },
       }}
       className="cashflow-chart min-h-[200px] w-full"
     >
@@ -83,6 +91,9 @@ const CashflowChart: FC<CashflowChartProps> = ({
           horizontal={true}
           vertical={true}
         />
+        {typeof breakevenPoint === "number" && (
+          <ReferenceLine x={breakevenPoint} stroke="hsl(var(--destructive))" />
+        )}
         <YAxis
           axisLine={false}
           tickLine={false}
@@ -125,6 +136,13 @@ const CashflowChart: FC<CashflowChartProps> = ({
           stroke={CHART_COLORS.cumulativeNetIncomePlan}
           dot={false}
           strokeWidth={2}
+        />
+        {/* Ensure breakeven point is part of the chart and visible in the legend */}
+        <Line
+          type="linear"
+          dataKey="breakevenPoint"
+          stroke="hsl(var(--destructive))"
+          hide={true}
         />
         <XAxis
           dataKey="year"

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
@@ -153,7 +153,7 @@ const CashflowChart: FC<CashflowChartProps> = ({
             const { x, y, payload } = props;
 
             // Not sure if needed, and from which number to count?
-            if (payload.value < 0) return <g></g>;
+            if (payload.value === 0) return <g></g>;
 
             return (
               <g transform={`translate(${x + 10},${y + 60})`}>

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 
 import { YearlyBreakdown } from "@shared/dtos/custom-projects/custom-project-output.dto";
+import { CARBON_REVENUES_TO_COVER } from "@shared/entities/custom-project.entity";
 
 import { useProjectCashFlowTab } from "@/app/projects/url-store";
 
@@ -14,10 +15,12 @@ import { Card } from "@/components/ui/card";
 interface AnnualProjectCashFlowProps {
   chartData: YearlyBreakdownChartData;
   tableData: YearlyBreakdown[];
+  carbonRevenuesToCover?: CARBON_REVENUES_TO_COVER;
 }
 const AnnualProjectCashFlow: FC<AnnualProjectCashFlowProps> = ({
   tableData,
   chartData,
+  carbonRevenuesToCover,
 }) => {
   const [tab] = useProjectCashFlowTab();
   return (
@@ -26,7 +29,10 @@ const AnnualProjectCashFlow: FC<AnnualProjectCashFlowProps> = ({
       {tab === "table" ? (
         <CashFlowTable data={tableData} />
       ) : (
-        <CashflowChart data={chartData} />
+        <CashflowChart
+          data={chartData}
+          carbonRevenuesToCover={carbonRevenuesToCover}
+        />
       )}
     </Card>
   );

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx
@@ -15,11 +15,13 @@ import { Card } from "@/components/ui/card";
 interface AnnualProjectCashFlowProps {
   chartData: YearlyBreakdownChartData;
   tableData: YearlyBreakdown[];
+  breakevenPoint: number | null;
   carbonRevenuesToCover?: CARBON_REVENUES_TO_COVER;
 }
 const AnnualProjectCashFlow: FC<AnnualProjectCashFlowProps> = ({
   tableData,
   chartData,
+  breakevenPoint,
   carbonRevenuesToCover,
 }) => {
   const [tab] = useProjectCashFlowTab();
@@ -32,6 +34,7 @@ const AnnualProjectCashFlow: FC<AnnualProjectCashFlowProps> = ({
         <CashflowChart
           data={chartData}
           carbonRevenuesToCover={carbonRevenuesToCover}
+          breakevenPoint={breakevenPoint}
         />
       )}
     </Card>

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/utils.ts
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/utils.ts
@@ -3,6 +3,7 @@ import {
   YearlyBreakdown,
   YearlyBreakdownCostName,
 } from "@shared/dtos/custom-projects/custom-project-output.dto";
+import { CARBON_REVENUES_TO_COVER } from "@shared/entities/custom-project.entity";
 
 function getBreakdownYears(data: YearlyBreakdown[]): number[] {
   if (data.length === 0) return [];
@@ -181,10 +182,18 @@ function parseYearlyBreakdownForTable(
   });
 }
 
+const cumulativeNetIncomePlanTooltipLabel = {
+  [CARBON_REVENUES_TO_COVER.OPEX]:
+    "Cumulative net income (NPV) (Revenue - OpEx)",
+  [CARBON_REVENUES_TO_COVER.CAPEX_AND_OPEX]:
+    "Cumulative net income (NPV) (Revenue - CapEx - OpEx)",
+} as const;
+
 export {
   getBreakdownYears,
   parseYearlyBreakdownForChart,
   parseYearlyBreakdownForTable,
   cashflowConfig,
+  cumulativeNetIncomePlanTooltipLabel,
   type YearlyBreakdownChartData,
 };

--- a/client/src/containers/projects/custom-project/index.tsx
+++ b/client/src/containers/projects/custom-project/index.tsx
@@ -48,8 +48,7 @@ const CustomProjectView: FC<{
     projectDetailsProps,
     leftOverProps,
     costDetailsProps,
-    chartData,
-    tableData,
+    annualProjectCashFlowProps,
     summaryData,
   } = useCustomProjectOutput(data);
 
@@ -99,7 +98,7 @@ const CustomProjectView: FC<{
           {leftOverProps && <LeftOver {...leftOverProps} />}
           {costDetailsProps && <CostDetails data={costDetailsProps} />}
         </div>
-        <AnnualProjectCashFlow tableData={tableData} chartData={chartData} />
+        <AnnualProjectCashFlow {...annualProjectCashFlowProps} />
       </div>
     </motion.div>
   );

--- a/client/src/hooks/use-custom-project-output.ts
+++ b/client/src/hooks/use-custom-project-output.ts
@@ -115,7 +115,7 @@ export const useCustomProjectOutput = (
       chartData,
       carbonRevenuesToCover: output?.carbonRevenuesToCover,
       breakevenPoint:
-        chartData.find((item) => item.cumulativeNetIncomePlan >= 0)?.year ||
+        chartData.find((item) => item.cumulativeNetIncomePlan > 0)?.year ||
         null,
     }),
     [tableData, chartData, output?.carbonRevenuesToCover],

--- a/client/src/hooks/use-custom-project-output.ts
+++ b/client/src/hooks/use-custom-project-output.ts
@@ -109,14 +109,21 @@ export const useCustomProjectOutput = (
       data: output?.leftover[costRangeSelector],
     };
   }, [output?.leftover, costRangeSelector, data.input.carbonRevenuesToCover]);
+  const annualProjectCashFlowProps = useMemo(
+    () => ({
+      tableData,
+      chartData,
+      carbonRevenuesToCover: output?.carbonRevenuesToCover,
+    }),
+    [tableData, chartData, output?.carbonRevenuesToCover],
+  );
 
   return {
     projectCostProps: output?.totalProjectCost[costRangeSelector],
     leftOverProps,
     projectDetailsProps,
     costDetailsProps,
-    chartData,
-    tableData,
+    annualProjectCashFlowProps,
     summaryData,
     output,
   };

--- a/client/src/hooks/use-custom-project-output.ts
+++ b/client/src/hooks/use-custom-project-output.ts
@@ -114,6 +114,9 @@ export const useCustomProjectOutput = (
       tableData,
       chartData,
       carbonRevenuesToCover: output?.carbonRevenuesToCover,
+      breakevenPoint:
+        chartData.find((item) => item.cumulativeNetIncomePlan >= 0)?.year ||
+        null,
     }),
     [tableData, chartData, output?.carbonRevenuesToCover],
   );


### PR DESCRIPTION
## Add Breakeven Point and Revenue Coverage to Cash Flow Chart

### Changes
- Added a breakeven point reference line to the cash flow chart
- Updated chart tooltips to show different labels based on carbon revenue coverage type (OpEx vs CapEx+OpEx)
- Added visual indicator for breakeven point in chart legend

### Jira
- [TBCCT-317](https://vizzuality.atlassian.net/browse/TBCCT-317)
- [TBCCT-315](https://vizzuality.atlassian.net/browse/TBCCT-315)
- [TBCCT-321](https://vizzuality.atlassian.net/browse/TBCCT-321)

[TBCCT-317]: https://vizzuality.atlassian.net/browse/TBCCT-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TBCCT-315]: https://vizzuality.atlassian.net/browse/TBCCT-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TBCCT-321]: https://vizzuality.atlassian.net/browse/TBCCT-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ