### PR TITLE
fix: Remove ProjectSize -> ModelComponentSource relationship

### DIFF
--- a/backoffice/resources/project-size/project-size.resource.ts
+++ b/backoffice/resources/project-size/project-size.resource.ts
@@ -12,27 +12,9 @@ export const ProjectSizeResource: ResourceWithOptions = {
       name: 'Data Management',
       icon: 'Database',
     },
-    listProperties: [
-      'countryCode',
-      'ecosystem',
-      'activity',
-      'sizeHa',
-      'source',
-    ],
-    showProperties: [
-      'countryCode',
-      'ecosystem',
-      'activity',
-      'sizeHa',
-      'source',
-    ],
-    editProperties: [
-      'countryCode',
-      'ecosystem',
-      'activity',
-      'sizeHa',
-      'source',
-    ],
+    listProperties: ['countryCode', 'ecosystem', 'activity', 'sizeHa'],
+    showProperties: ['countryCode', 'ecosystem', 'activity', 'sizeHa'],
+    editProperties: ['countryCode', 'ecosystem', 'activity', 'sizeHa'],
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
       sizeHa: {
@@ -40,10 +22,6 @@ export const ProjectSizeResource: ResourceWithOptions = {
         type: 'number',
         isVisible: { list: true, show: true, edit: true, filter: false },
         description: 'Size in hectares',
-      },
-      source: {
-        position: 5,
-        isVisible: { list: true, show: true, edit: true, filter: false },
       },
     },
   },

--- a/shared/entities/cost-inputs/project-size.entity.ts
+++ b/shared/entities/cost-inputs/project-size.entity.ts
@@ -10,7 +10,6 @@ import {
 import { Country } from "@shared/entities/country.entity";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 import { ACTIVITY } from "@shared/entities/activity.enum";
-import { ModelComponentSource } from "@shared/entities/methodology/model-component-source.entity";
 
 @Entity({ name: "project_sizes" })
 @Unique(["country", "ecosystem", "activity"])


### PR DESCRIPTION
This pull request includes changes to the `ProjectSizeResource` in the backoffice module and the `project-size.entity.ts` file in the shared module. The changes are primarily focused on simplifying the properties and removing unnecessary imports.

Changes to `ProjectSizeResource`:

* Removed the `source` property from `listProperties`, `showProperties`, and `editProperties` arrays (`backoffice/resources/project-size/project-size.resource.ts`).
* Removed the `source` property definition from the `properties` object (`backoffice/resources/project-size/project-size.resource.ts`).

Changes to `project-size.entity.ts`:

* Removed the import statement for `ModelComponentSource` as it is no longer used (`shared/entities/cost-inputs/project-size.entity.ts`).