### PR TITLE
Fix model component sources subquery because it was incompatible with the env postgres version

### DIFF
--- a/api/src/modules/methodology/methodology.repository.ts
+++ b/api/src/modules/methodology/methodology.repository.ts
@@ -34,7 +34,7 @@ export class MethodologyRepository {
         SELECT
             '${sourceConfig.category}' AS category, 
             '${sourceConfig.label}' AS name, 
-            JSONB_OBJECT_AGG(source_type, sources) AS sources
+            JSONB_OBJECT_AGG(sources_subquery.source_type, sources_subquery.sources) AS sources
         FROM
         (
             SELECT 
@@ -55,7 +55,7 @@ export class MethodologyRepository {
                 ORDER BY t2.source_type, t1.id, t1.name
             ) AS source_distinct
             GROUP BY source_distinct.source_type
-        ) UNION ALL`;
+        ) AS sources_subquery UNION ALL`;
       }
     }
     if (this.manyToManySourcesSql === '') {


### PR DESCRIPTION
This pull request includes changes to the `MethodologyRepository` class in the `methodology.repository.ts` file to improve the handling and aggregation of source data in SQL queries. The most important changes include modifying the SQL query to use a subquery for source aggregation and ensuring proper aliasing.

Changes to SQL query handling:

* [`api/src/modules/methodology/methodology.repository.ts`](diffhunk://#diff-92d32f6cd50ecf42229438cfd17545920ce8096be812381d7f96c89f6c3bb603L37-R37): Modified the SQL query to use `sources_subquery` for source type and sources aggregation in the `JSONB_OBJECT_AGG` function.
* [`api/src/modules/methodology/methodology.repository.ts`](diffhunk://#diff-92d32f6cd50ecf42229438cfd17545920ce8096be812381d7f96c89f6c3bb603L58-R58): Ensured proper aliasing of the subquery as `sources_subquery` in the UNION ALL clause.