### PR TITLE
fix: form crash restoration project-length input

### DIFF
--- a/client/src/containers/projects/form/restoration-plan/index.tsx
+++ b/client/src/containers/projects/form/restoration-plan/index.tsx
@@ -72,18 +72,18 @@ export default function RestorationPlanProjectForm() {
     ? Number(projectLength)
     : defaultRestorationProjectLength;
 
-  const DATA = useMemo(
-    () =>
-      Array.from({
-        length: (totalYears as NonNullable<typeof totalYears>) + 2,
-      })
-        .map((_, i) => ({
-          year: i - 1,
-          annualHectaresRestored: 0,
-        }))
-        .filter(({ year }) => year != 0),
-    [totalYears],
-  );
+  const DATA = useMemo(() => {
+    // Prevent array length from being greater than 42:
+    const arrayLength = totalYears && totalYears <= 40 ? totalYears + 2 : 42;
+    return Array.from({
+      length: arrayLength,
+    })
+      .map((_, i) => ({
+        year: i - 1,
+        annualHectaresRestored: 0,
+      }))
+      .filter(({ year }) => year != 0);
+  }, [totalYears]);
 
   const table = useReactTable({
     data: DATA,

--- a/client/src/containers/projects/form/restoration-plan/index.tsx
+++ b/client/src/containers/projects/form/restoration-plan/index.tsx
@@ -14,6 +14,7 @@ import { queryKeys } from "@/lib/query-keys";
 import { useFormValues } from "@/containers/projects/form/project-form";
 import { COLUMNS } from "@/containers/projects/form/restoration-plan/columns";
 import { CustomProjectForm } from "@/containers/projects/form/setup";
+import { getRestorationPlanTableData } from "@/containers/projects/form/utils";
 
 import {
   Accordion,
@@ -68,27 +69,14 @@ export default function RestorationPlanProjectForm() {
       },
     );
 
-  const totalYears = projectLength
-    ? Number(projectLength)
-    : defaultRestorationProjectLength;
-
-  const DATA = useMemo(() => {
-    let arrayLength: number = 0;
-
-    // Prevent array length from being greater than 42:
-    if (totalYears && totalYears > 0 && totalYears <= 40) {
-      arrayLength = totalYears + 2;
-    }
-
-    return Array.from({
-      length: arrayLength,
-    })
-      .map((_, i) => ({
-        year: i - 1,
-        annualHectaresRestored: 0,
-      }))
-      .filter(({ year }) => year != 0);
-  }, [totalYears]);
+  const DATA = useMemo(
+    () =>
+      getRestorationPlanTableData(
+        projectLength,
+        defaultRestorationProjectLength,
+      ),
+    [projectLength, defaultRestorationProjectLength],
+  );
 
   const table = useReactTable({
     data: DATA,

--- a/client/src/containers/projects/form/restoration-plan/index.tsx
+++ b/client/src/containers/projects/form/restoration-plan/index.tsx
@@ -74,7 +74,11 @@ export default function RestorationPlanProjectForm() {
 
   const DATA = useMemo(() => {
     // Prevent array length from being greater than 42:
-    const arrayLength = totalYears && totalYears <= 40 ? totalYears + 2 : 42;
+    let arrayLength: number = 0;
+
+    if (totalYears) {
+      arrayLength = totalYears <= 40 ? totalYears + 2 : 42;
+    }
     return Array.from({
       length: arrayLength,
     })

--- a/client/src/containers/projects/form/restoration-plan/index.tsx
+++ b/client/src/containers/projects/form/restoration-plan/index.tsx
@@ -73,12 +73,13 @@ export default function RestorationPlanProjectForm() {
     : defaultRestorationProjectLength;
 
   const DATA = useMemo(() => {
-    // Prevent array length from being greater than 42:
     let arrayLength: number = 0;
 
-    if (totalYears) {
-      arrayLength = totalYears <= 40 ? totalYears + 2 : 42;
+    // Prevent array length from being greater than 42:
+    if (totalYears && totalYears > 0 && totalYears <= 40) {
+      arrayLength = totalYears + 2;
     }
+
     return Array.from({
       length: arrayLength,
     })

--- a/client/src/containers/projects/form/utils.ts
+++ b/client/src/containers/projects/form/utils.ts
@@ -7,6 +7,7 @@ import { ApiResponse } from "@shared/dtos/global/api-response.dto";
 import { ACTIVITY } from "@shared/entities/activity.enum";
 import { CustomProject } from "@shared/entities/custom-project.entity";
 import { ASSUMPTIONS_NAME_TO_DTO_MAP } from "@shared/schemas/assumptions/assumptions.enums";
+import { MAX_PROJECT_LENGTH } from "@shared/schemas/custom-projects/create-custom-project.schema";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
@@ -20,6 +21,7 @@ import {
   DEFAULT_COMMON_FORM_VALUES,
   DEFAULT_CONSERVATION_FORM_VALUES,
 } from "@/containers/projects/form/constants";
+import { RestorationPlanFormProperty } from "@/containers/projects/form/restoration-plan/columns";
 import { CustomProjectForm } from "@/containers/projects/form/setup";
 
 export const parseFormValues = (data: CustomProjectForm) => {
@@ -320,3 +322,32 @@ export const useCustomProjectForm = () => {
     handleFormChange,
   };
 };
+
+/**
+ *
+ * @param projectLength - The number of years the restoration project will run
+ *
+ * @param defaultLength - Fallback length to use if projectLength is not provided
+ *
+ * @returns An array of yearly restoration data where:
+ *          - First entry is year -1
+ *          - Followed by years 1 through projectLength
+ */
+export function getRestorationPlanTableData(
+  projectLength?: number | null,
+  defaultLength?: number,
+): RestorationPlanFormProperty[] {
+  const totalYears = projectLength ? Number(projectLength) : defaultLength;
+
+  if (!totalYears || totalYears <= 0 || totalYears > MAX_PROJECT_LENGTH) {
+    return [];
+  }
+
+  return [
+    { year: -1, annualHectaresRestored: 0 },
+    ...Array.from({ length: totalYears }, (_, i) => ({
+      year: i + 1,
+      annualHectaresRestored: 0,
+    })),
+  ];
+}

--- a/client/src/containers/projects/form/utils.ts
+++ b/client/src/containers/projects/form/utils.ts
@@ -329,6 +329,8 @@ export const useCustomProjectForm = () => {
  *
  * @param defaultLength - Fallback length to use if projectLength is not provided
  *
+ * @param maxProjectLength - The maximum number of years the restoration project can run
+ *
  * @returns An array of yearly restoration data where:
  *          - First entry is year -1
  *          - Followed by years 1 through projectLength
@@ -336,10 +338,16 @@ export const useCustomProjectForm = () => {
 export function getRestorationPlanTableData(
   projectLength?: number | null,
   defaultLength?: number,
+  maxProjectLength?: number,
 ): RestorationPlanFormProperty[] {
   const totalYears = projectLength ? Number(projectLength) : defaultLength;
+  let maxYears = MAX_PROJECT_LENGTH;
 
-  if (!totalYears || totalYears <= 0 || totalYears > MAX_PROJECT_LENGTH) {
+  if (typeof maxProjectLength === "number" && maxProjectLength > 0) {
+    maxYears = maxProjectLength;
+  }
+
+  if (!totalYears || totalYears <= 0 || totalYears > maxYears) {
     return [];
   }
 

--- a/client/tests/projects/form/utils.test.ts
+++ b/client/tests/projects/form/utils.test.ts
@@ -1,0 +1,52 @@
+import { MAX_PROJECT_LENGTH } from "@shared/schemas/custom-projects/create-custom-project.schema";
+
+import { getRestorationPlanTableData } from "@/containers/projects/form/utils";
+
+describe("projects/form/utils", () => {
+  // this array is used to test the actual output
+  // it is based on  a project length of 2 years, which makes the total length 2 + 1 (for the year -1)
+  const RESTORATION_PLAN_DATA = [
+    { year: -1, annualHectaresRestored: 0 },
+    { year: 1, annualHectaresRestored: 0 },
+    { year: 2, annualHectaresRestored: 0 },
+  ];
+  const projectLength = 2;
+
+  describe("getRestorationPlanTableData", () => {
+    it("should return an empty array if projectLength and defaultLength are not specified", () => {
+      const result = getRestorationPlanTableData();
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("should use the defaultLength if projectLength is not specified and defaultLength is provided", () => {
+      const result = getRestorationPlanTableData(undefined, projectLength);
+      expect(result).toEqual(RESTORATION_PLAN_DATA);
+      expect(result).toHaveLength(RESTORATION_PLAN_DATA.length);
+    });
+
+    it("should use projectLength when it is specified", () => {
+      const result = getRestorationPlanTableData(projectLength);
+      expect(result).toEqual(RESTORATION_PLAN_DATA);
+      expect(result).toHaveLength(RESTORATION_PLAN_DATA.length);
+    });
+
+    it("should prioritize projectLength over defaultLength when both are provided", () => {
+      const defaultLength = 3;
+      const result = getRestorationPlanTableData(projectLength, defaultLength);
+      expect(result).toEqual(RESTORATION_PLAN_DATA);
+      expect(result).toHaveLength(RESTORATION_PLAN_DATA.length);
+    });
+
+    test.each([
+      ["zero", 0],
+      ["negative", -1],
+      ["large negative", -1000],
+      ["exceeding maximum", MAX_PROJECT_LENGTH + 1],
+      ["far exceeding maximum", MAX_PROJECT_LENGTH + 1000],
+    ])("should return an empty array when projectLength is %s", (_, length) => {
+      const result = getRestorationPlanTableData(length);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/client/tests/projects/form/utils.test.ts
+++ b/client/tests/projects/form/utils.test.ts
@@ -3,50 +3,93 @@ import { MAX_PROJECT_LENGTH } from "@shared/schemas/custom-projects/create-custo
 import { getRestorationPlanTableData } from "@/containers/projects/form/utils";
 
 describe("projects/form/utils", () => {
-  // this array is used to test the actual output
-  // it is based on  a project length of 2 years, which makes the total length 2 + 1 (for the year -1)
-  const RESTORATION_PLAN_DATA = [
-    { year: -1, annualHectaresRestored: 0 },
-    { year: 1, annualHectaresRestored: 0 },
-    { year: 2, annualHectaresRestored: 0 },
-  ];
-  const projectLength = 2;
-
   describe("getRestorationPlanTableData", () => {
-    it("should return an empty array if projectLength and defaultLength are not specified", () => {
-      const result = getRestorationPlanTableData();
-      expect(result).toEqual([]);
-      expect(result).toHaveLength(0);
+    const projectLength = 2;
+    // this array is used to test the actual output
+    // it is based on  a project length of 2 years, which makes the total length 2 + 1 (for the year -1)
+    const baseTestData = [
+      { year: -1, annualHectaresRestored: 0 },
+      { year: 1, annualHectaresRestored: 0 },
+      { year: 2, annualHectaresRestored: 0 },
+    ];
+
+    describe("basic functionality", () => {
+      it("should return an empty array if no lengths are specified", () => {
+        expect(getRestorationPlanTableData()).toEqual([]);
+      });
+
+      it("should use defaultLength when projectLength is not specified", () => {
+        expect(getRestorationPlanTableData(undefined, projectLength)).toEqual(
+          baseTestData,
+        );
+      });
+
+      it("should use projectLength when specified", () => {
+        expect(getRestorationPlanTableData(projectLength)).toEqual(
+          baseTestData,
+        );
+      });
+
+      it("should prioritize projectLength over defaultLength", () => {
+        expect(getRestorationPlanTableData(projectLength, 3)).toEqual(
+          baseTestData,
+        );
+      });
     });
 
-    it("should use the defaultLength if projectLength is not specified and defaultLength is provided", () => {
-      const result = getRestorationPlanTableData(undefined, projectLength);
-      expect(result).toEqual(RESTORATION_PLAN_DATA);
-      expect(result).toHaveLength(RESTORATION_PLAN_DATA.length);
+    describe("maxProjectLength handling", () => {
+      const customMaxLength = 10;
+
+      it("should respect MAX_PROJECT_LENGTH constant", () => {
+        const result = getRestorationPlanTableData(MAX_PROJECT_LENGTH);
+        expect(result).toHaveLength(MAX_PROJECT_LENGTH + 1);
+      });
+
+      it.each<[string, number | undefined, number, number | undefined]>([
+        ["less than max", 5, 6, undefined],
+        ["equal to max", customMaxLength, customMaxLength + 1, undefined],
+        ["exceeding max", 15, 0, undefined],
+        ["with defaultLength", undefined, 9, 8],
+      ])(
+        "should handle when projectLength is %s",
+        (_, length, expected, defaultLength) => {
+          const result = getRestorationPlanTableData(
+            length,
+            defaultLength,
+            customMaxLength,
+          );
+          expect(result).toHaveLength(expected);
+        },
+      );
     });
 
-    it("should use projectLength when it is specified", () => {
-      const result = getRestorationPlanTableData(projectLength);
-      expect(result).toEqual(RESTORATION_PLAN_DATA);
-      expect(result).toHaveLength(RESTORATION_PLAN_DATA.length);
-    });
+    describe("invalid inputs", () => {
+      it.each([
+        ["zero", 0],
+        ["negative", -1],
+        ["undefined", undefined],
+        ["null", null],
+      ])("should ignore invalid maxProjectLength: %s", (_, maxLength) => {
+        const result = getRestorationPlanTableData(
+          5,
+          undefined,
+          maxLength as number,
+        );
+        expect(result).toHaveLength(6);
+      });
 
-    it("should prioritize projectLength over defaultLength when both are provided", () => {
-      const defaultLength = 3;
-      const result = getRestorationPlanTableData(projectLength, defaultLength);
-      expect(result).toEqual(RESTORATION_PLAN_DATA);
-      expect(result).toHaveLength(RESTORATION_PLAN_DATA.length);
-    });
-
-    test.each([
-      ["zero", 0],
-      ["negative", -1],
-      ["large negative", -1000],
-      ["exceeding maximum", MAX_PROJECT_LENGTH + 1],
-      ["far exceeding maximum", MAX_PROJECT_LENGTH + 1000],
-    ])("should return an empty array when projectLength is %s", (_, length) => {
-      const result = getRestorationPlanTableData(length);
-      expect(result).toHaveLength(0);
+      it.each([
+        ["zero", 0],
+        ["negative", -1],
+        ["large negative", -1000],
+        ["exceeding maximum", MAX_PROJECT_LENGTH + 1],
+        ["far exceeding maximum", MAX_PROJECT_LENGTH + 1000],
+      ])(
+        "should return empty array for invalid projectLength: %s",
+        (_, length) => {
+          expect(getRestorationPlanTableData(length)).toHaveLength(0);
+        },
+      );
     });
   });
 });

--- a/shared/schemas/custom-projects/create-custom-project.schema.ts
+++ b/shared/schemas/custom-projects/create-custom-project.schema.ts
@@ -11,6 +11,7 @@ import {
 } from "@shared/entities/custom-project.entity";
 import { SEQUESTRATION_RATE_TIER_TYPES } from "@shared/entities/carbon-inputs/sequestration-rate.entity";
 
+export const MAX_PROJECT_LENGTH = 40;
 export enum LOSS_RATE_USED {
   NATIONAL_AVERAGE = "National average",
   PROJECT_SPECIFIC = "Project specific",
@@ -88,9 +89,13 @@ export const AssumptionsSchema = z.object({
   projectLength: z
     .preprocess(
       parseNumber,
-      z.number().positive().min(1).max(40, {
-        message: "Project Length should be between 1 and 40 years",
-      }),
+      z
+        .number()
+        .positive()
+        .min(1)
+        .max(MAX_PROJECT_LENGTH, {
+          message: `Project Length should be between 1 and ${MAX_PROJECT_LENGTH} years`,
+        }),
     )
     .optional(),
 });


### PR DESCRIPTION
### Changes
- Extracted restoration plan table data generation logic into a separate utility function `getRestorationPlanTableData`
- Added input validation for project length values
- Added unit tests for the new utility function
- Introduced `MAX_PROJECT_LENGTH` constant (40 years) for better maintainability
- Added optional function argument to adjust maxProjectLength