### PR TITLE
[TBCCT-327] fixes missing plantingSuccessRate value during form validation

### DIFF
--- a/client/src/containers/projects/form/constants.ts
+++ b/client/src/containers/projects/form/constants.ts
@@ -1,4 +1,7 @@
-import { ACTIVITY } from "@shared/entities/activity.enum";
+import {
+  ACTIVITY,
+  RESTORATION_ACTIVITY_SUBTYPE,
+} from "@shared/entities/activity.enum";
 import { EMISSION_FACTORS_TIER_TYPES } from "@shared/entities/carbon-inputs/emission-factors.entity";
 import {
   CARBON_REVENUES_TO_COVER,
@@ -13,6 +16,7 @@ import {
 import { z } from "zod";
 
 import { CustomProjectForm } from "@/containers/projects/form/setup";
+import { SEQUESTRATION_RATE_TIER_TYPES } from "@shared/entities/carbon-inputs/sequestration-rate.entity";
 
 export const DEFAULT_COMMON_FORM_VALUES: Omit<
   CustomProjectForm,
@@ -59,13 +63,20 @@ export const DEFAULT_RESTORATION_FORM_VALUES: Pick<
 > & {
   parameters: Pick<
     z.infer<typeof RestorationCustomProjectSchema>,
-    "plantingSuccessRate" | "projectSpecificSequestrationRate"
+    | "restorationActivity"
+    | "tierSelector"
+    | "plantingSuccessRate"
+    | "projectSpecificSequestrationRate"
+    | "restorationYearlyBreakdown"
   >;
 } = {
   activity: ACTIVITY.RESTORATION,
   projectSizeHa: 100,
   parameters: {
+    restorationActivity: RESTORATION_ACTIVITY_SUBTYPE.PLANTING,
+    tierSelector: SEQUESTRATION_RATE_TIER_TYPES.TIER_1,
     plantingSuccessRate: 0.8,
     projectSpecificSequestrationRate: 15,
+    restorationYearlyBreakdown: [],
   },
 };

--- a/client/src/containers/projects/form/cost-inputs-overrides/capex/index.tsx
+++ b/client/src/containers/projects/form/cost-inputs-overrides/capex/index.tsx
@@ -33,7 +33,7 @@ export default function CapexCostInputsTable() {
     ecosystem,
     countryCode,
     activity,
-    restorationActivity,
+    ...(activity === ACTIVITY.RESTORATION && { restorationActivity }),
   });
 
   const { data, isSuccess } =

--- a/client/src/containers/projects/form/cost-inputs-overrides/opex/index.tsx
+++ b/client/src/containers/projects/form/cost-inputs-overrides/opex/index.tsx
@@ -33,7 +33,7 @@ export default function OpexCostInputsTable() {
     ecosystem,
     countryCode,
     activity,
-    restorationActivity,
+    ...(activity === ACTIVITY.RESTORATION && { restorationActivity }),
   });
   const { data, isSuccess } =
     client.customProjects.getDefaultCostInputs.useQuery(

--- a/client/src/containers/projects/form/cost-inputs-overrides/other/index.tsx
+++ b/client/src/containers/projects/form/cost-inputs-overrides/other/index.tsx
@@ -33,7 +33,7 @@ export default function OtherCostInputsTable() {
     ecosystem,
     countryCode,
     activity,
-    restorationActivity,
+    ...(activity === ACTIVITY.RESTORATION && { restorationActivity }),
   });
   const { data, isSuccess } =
     client.customProjects.getDefaultCostInputs.useQuery(

--- a/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
+++ b/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
@@ -10,7 +10,6 @@ import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 import { client } from "@/lib/query-client";
 import { queryKeys } from "@/lib/query-keys";
 
-import { DEFAULT_RESTORATION_FORM_VALUES } from "@/containers/projects/form/constants";
 import NumberFormItem from "@/containers/projects/form/number-form-item";
 import { useCustomProjectForm } from "@/containers/projects/form/utils";
 
@@ -189,9 +188,7 @@ export default function RestorationProjectDetails() {
                 formItemClassName="basis-1/2"
                 formControlClassName="after:content-['%']"
                 min={0}
-                initialValue={
-                  DEFAULT_RESTORATION_FORM_VALUES.parameters.plantingSuccessRate
-                }
+                initialValue={form.getValues("parameters.plantingSuccessRate")}
                 isPercentage
                 readOnly
                 disabled
@@ -255,13 +252,9 @@ export default function RestorationProjectDetails() {
                     formItemClassName="basis-1/2"
                     formControlClassName="after:content-['tCO2e/ha/yr']"
                     min={0}
-                    initialValue={
-                      form.getValues(
-                        "parameters.projectSpecificSequestrationRate",
-                      ) ??
-                      DEFAULT_RESTORATION_FORM_VALUES.parameters
-                        .projectSpecificSequestrationRate
-                    }
+                    initialValue={form.getValues(
+                      "parameters.projectSpecificSequestrationRate",
+                    )}
                     onValueChange={async (v) =>
                       handleFormChange(
                         "parameters.projectSpecificSequestrationRate",

--- a/client/src/containers/projects/form/utils.ts
+++ b/client/src/containers/projects/form/utils.ts
@@ -43,8 +43,9 @@ export const parseFormValues = (data: CustomProjectForm) => {
       ecosystem: data.ecosystem,
       activity: data.activity,
       countryCode: data.countryCode,
-      // @ts-expect-error fix later
-      restorationActivity: data.parameters?.restorationActivity,
+      ...(data.activity === ACTIVITY.RESTORATION && {
+        restorationActivity: data.parameters?.restorationActivity,
+      }),
     }).queryKey,
   );
 

--- a/client/src/containers/projects/form/utils.ts
+++ b/client/src/containers/projects/form/utils.ts
@@ -19,6 +19,7 @@ import { getQueryClient } from "@/app/providers";
 import {
   DEFAULT_COMMON_FORM_VALUES,
   DEFAULT_CONSERVATION_FORM_VALUES,
+  DEFAULT_RESTORATION_FORM_VALUES,
 } from "@/containers/projects/form/constants";
 import { CustomProjectForm } from "@/containers/projects/form/setup";
 
@@ -257,6 +258,10 @@ export const useDefaultFormValues = (id?: string): CustomProjectForm => {
     activity: ACTIVITY.CONSERVATION,
     countryCode: countryOptions?.[0]?.value ?? "",
     initialCarbonPriceAssumption,
+    parameters: {
+      ...DEFAULT_CONSERVATION_FORM_VALUES.parameters,
+      ...DEFAULT_RESTORATION_FORM_VALUES.parameters,
+    },
   };
 };
 

--- a/client/tests/projects/form/default-values.test.tsx
+++ b/client/tests/projects/form/default-values.test.tsx
@@ -3,17 +3,16 @@ import { renderHook } from "@testing-library/react";
 import { useDefaultFormValues } from "@/containers/projects/form/utils";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 import { ACTIVITY } from "@shared/entities/activity.enum";
-import {
-  CARBON_REVENUES_TO_COVER,
-  PROJECT_SPECIFIC_EMISSION,
-} from "@shared/entities/custom-project.entity";
-import { LOSS_RATE_USED } from "@shared/schemas/custom-projects/create-custom-project.schema";
-import { EMISSION_FACTORS_TIER_TYPES } from "@shared/entities/carbon-inputs/emission-factors.entity";
+import { CARBON_REVENUES_TO_COVER } from "@shared/entities/custom-project.entity";
 import { COUNTRY_LIST, DEFAULT_ASSUMPTIONS, FAKE_PROJECT } from "./constants";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren } from "react";
 import { queryKeys } from "@/lib/query-keys";
+import {
+  DEFAULT_CONSERVATION_FORM_VALUES,
+  DEFAULT_RESTORATION_FORM_VALUES,
+} from "@/containers/projects/form/constants";
 
 const queryClient = new QueryClient();
 
@@ -71,14 +70,9 @@ describe("projects/form/default-values", () => {
       restorationRate: undefined,
       verificationFrequency: undefined,
     });
-    expect(defaultValues.current.parameters).toMatchObject({
-      projectSpecificLossRate: -0.003,
-      projectSpecificEmissionFactor: 15,
-      emissionFactorAGB: 200,
-      emissionFactorSOC: 15,
-      lossRateUsed: LOSS_RATE_USED.PROJECT_SPECIFIC,
-      emissionFactorUsed: EMISSION_FACTORS_TIER_TYPES.TIER_1,
-      projectSpecificEmission: PROJECT_SPECIFIC_EMISSION.ONE_EMISSION_FACTOR,
+    expect(defaultValues.current.parameters).toEqual({
+      ...DEFAULT_CONSERVATION_FORM_VALUES.parameters,
+      ...DEFAULT_RESTORATION_FORM_VALUES.parameters,
     });
   });
 
@@ -109,10 +103,10 @@ describe("projects/form/default-values", () => {
     expect(defaultValues.current.carbonRevenuesToCover).equal(
       FAKE_PROJECT.input.carbonRevenuesToCover,
     );
-    expect(defaultValues.current.assumptions).toMatchObject(
+    expect(defaultValues.current.assumptions).toEqual(
       FAKE_PROJECT.input.assumptions,
     );
-    expect(defaultValues.current.parameters).toMatchObject(
+    expect(defaultValues.current.parameters).toEqual(
       FAKE_PROJECT.input.parameters,
     );
   });


### PR DESCRIPTION
This pull request includes changes to the `client/src/containers/projects/form` directory to enhance the handling of restoration projects. The most important changes involve updating constants, modifying form setup, and ensuring default values are correctly applied.

### Constants Update:
* [`client/src/containers/projects/form/constants.ts`](diffhunk://#diff-2ae025fd6400b66305aeeaf59766c0d3e22af6ebfd35f98f65b4439823d32dbdL1-R4): Added `RESTORATION_ACTIVITY_SUBTYPE` and `SEQUESTRATION_RATE_TIER_TYPES` to imports and updated `DEFAULT_RESTORATION_FORM_VALUES` to include new parameters such as `restorationActivity`, `tierSelector`, and `restorationYearlyBreakdown`. [[1]](diffhunk://#diff-2ae025fd6400b66305aeeaf59766c0d3e22af6ebfd35f98f65b4439823d32dbdL1-R4) [[2]](diffhunk://#diff-2ae025fd6400b66305aeeaf59766c0d3e22af6ebfd35f98f65b4439823d32dbdR19) [[3]](diffhunk://#diff-2ae025fd6400b66305aeeaf59766c0d3e22af6ebfd35f98f65b4439823d32dbdL62-R80)

### Form Setup Modifications:
* [`client/src/containers/projects/form/setup/restoration-project-detail/index.tsx`](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL13): Removed direct usage of `DEFAULT_RESTORATION_FORM_VALUES` for initial values and replaced it with `form.getValues` to dynamically fetch form values. [[1]](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL13) [[2]](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL192-R191) [[3]](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL258-R257)

### Default Values Application:
* [`client/src/containers/projects/form/utils.ts`](diffhunk://#diff-2f4ad3c5a8a1b8ff6665e0b366c5977cda5329321dbba75c3c9f32b88a7fc14bR22): Included `DEFAULT_RESTORATION_FORM_VALUES` in imports and merged its parameters with `DEFAULT_CONSERVATION_FORM_VALUES` in the `useDefaultFormValues` function to ensure proper default values are set. [[1]](diffhunk://#diff-2f4ad3c5a8a1b8ff6665e0b366c5977cda5329321dbba75c3c9f32b88a7fc14bR22) [[2]](diffhunk://#diff-2f4ad3c5a8a1b8ff6665e0b366c5977cda5329321dbba75c3c9f32b88a7fc14bR261-R264)

Jira: https://vizzuality.atlassian.net/browse/TBCCT-327