### PR TITLE
fix(api): Apply fix to the data-ingestion.xlsx-parse so it correctly parses data inside the 'Implementation labor' tab

### DIFF
--- a/api/src/modules/import/parser/data-ingestion.xlsx-parser.ts
+++ b/api/src/modules/import/parser/data-ingestion.xlsx-parser.ts
@@ -77,6 +77,23 @@ export class DataIngestionExcelParser implements IExcelParser {
         throw new ExcelTabNotFoundError(sheetName);
       }
 
+      // We make sure headers are trimmed.
+      // We cannot see the space preceding the tab heading if we open the file using google sheets, excel online or numbers on mac.
+      // Quick localized fix that only applies to the 'Implementation labor' tab in order to avoid potential issues with other tabs.
+      if (sheetName === 'Implementation labor') {
+        const tabHeaders = (
+          utils.sheet_to_json(sheet, { header: 1, raw: true })[0] as string[]
+        ).map((header: any) => header.trim());
+
+        const parsedSheet = utils.sheet_to_json(sheet, {
+          header: tabHeaders,
+          range: 1,
+          raw: true,
+        });
+        parsedData[sheetName] = parsedSheet;
+        continue;
+      }
+
       const parsedSheet = utils.sheet_to_json(sheet, {
         raw: true,
       });


### PR DESCRIPTION
This pull request introduces a fix to the `DataIngestionExcelParser` class to handle header trimming for a specific tab in Excel files. The change ensures that headers are trimmed for the 'Implementation labor' tab to avoid issues with leading spaces that may not be visible in various spreadsheet applications.

Key change:

* [`api/src/modules/import/parser/data-ingestion.xlsx-parser.ts`](diffhunk://#diff-7261aa4561bd64546afb142afbd91dc3c312e82695fb75b226b83bc8e537004fR80-R96): Added logic to trim headers specifically for the 'Implementation labor' tab to prevent potential issues with leading spaces in the tab headers.