### PR TITLE
fix: Apply missing constraints to the custom-project schema

### DIFF
--- a/api/test/integration/custom-projects/custom-projects-create.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-create.spec.ts
@@ -34,7 +34,7 @@ describe('Create Custom Projects - Setup', () => {
             verificationFrequency: 5,
             baselineReassessmentFrequency: 10,
             discountRate: 0.04,
-            restorationRate: 250,
+            // restorationRate: 250,
             carbonPriceIncrease: 0.015,
             buffer: 0.2,
             projectLength: 20,

--- a/api/test/integration/custom-projects/custom-projects-update.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-update.spec.ts
@@ -50,8 +50,11 @@ describe('Update custom projects', () => {
           lossRateUsed: LOSS_RATE_USED.NATIONAL_AVERAGE,
           emissionFactorUsed: EMISSION_FACTORS_TIER_TYPES.TIER_1,
           projectSpecificEmission: 'One emission factor',
-          projectSpecificLossRate: -0.5,
-          projectSpecificEmissionFactor: 0.5,
+          // These should be undefined
+          // projectSpecificLossRate: -0.5,
+          // projectSpecificEmissionFactor: 0.5,
+          projectSpecificLossRate: undefined,
+          projectSpecificEmissionFactor: undefined,
         },
       };
 

--- a/api/test/integration/custom-projects/custom-projects-validations.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-validations.spec.ts
@@ -54,8 +54,31 @@ describe('Create Custom Projects - Request Validations', () => {
       expect(errors[0]).toStrictEqual(
         expect.objectContaining({
           status: '400',
+          title: 'Required',
+          detail:
+            '{"code":"invalid_type","expected":"object","received":"undefined","path":["assumptions"],"message":"Required"}',
+        }),
+      );
+      expect(errors[1]).toStrictEqual(
+        expect.objectContaining({
+          status: '400',
+          title: 'Required',
+          detail:
+            '{"code":"invalid_type","expected":"object","received":"undefined","path":["costInputs"],"message":"Required"}',
+        }),
+      );
+      expect(errors[2]).toStrictEqual(
+        expect.objectContaining({
+          status: '400',
           title:
             "Invalid enum value. Expected 'National average' | 'Project specific', received 'Invalid'",
+        }),
+      );
+      expect(errors[3]).toStrictEqual(
+        expect.objectContaining({
+          status: '400',
+          title: 'Required',
+          detail: `{"expected":"'One emission factor' | 'Two emission factors'","received":"undefined","code":"invalid_type","path":["parameters","projectSpecificEmission"],"message":"Required"}`,
         }),
       );
     });
@@ -101,9 +124,35 @@ describe('Create Custom Projects - Request Validations', () => {
             emissionFactorUsed: PROJECT_EMISSION_FACTORS.TIER_2,
             projectSpecificEmission: 'One emission factor',
           },
+          assumptions: {
+            verificationFrequency: 1,
+            baselineReassessmentFrequency: 1,
+            discountRate: 1,
+            restorationRate: 1,
+            carbonPriceIncrease: 1,
+            buffer: 1,
+            projectLength: 1,
+          },
+          costInputs: {
+            feasibilityAnalysis: 1,
+            conservationPlanningAndAdmin: 1,
+            dataCollectionAndFieldCost: 1,
+            communityRepresentation: 1,
+            blueCarbonProjectPlanning: 1,
+            establishingCarbonRights: 1,
+            validation: 1,
+            implementationLabor: 1,
+            monitoring: 1,
+            maintenance: 1,
+            communityBenefitSharingFund: 1,
+            carbonStandardFees: 1,
+            baselineReassessment: 1,
+            mrv: 1,
+            longTermProjectOperatingCost: 1,
+            financingCost: 1,
+          },
         });
 
-      expect(res.body.errors).toHaveLength(1);
       expect(res.body.errors[0].title).toEqual(
         'There is only Tier 2 emission factor for Mangrove ecosystems',
       );
@@ -124,6 +173,33 @@ describe('Create Custom Projects - Request Validations', () => {
             lossRateUsed: 'National average',
             emissionFactorUsed: PROJECT_EMISSION_FACTORS.TIER_3,
             projectSpecificEmission: 'Two emission factors',
+          },
+          assumptions: {
+            verificationFrequency: 1,
+            baselineReassessmentFrequency: 1,
+            discountRate: 1,
+            restorationRate: 1,
+            carbonPriceIncrease: 1,
+            buffer: 1,
+            projectLength: 1,
+          },
+          costInputs: {
+            feasibilityAnalysis: 1,
+            conservationPlanningAndAdmin: 1,
+            dataCollectionAndFieldCost: 1,
+            communityRepresentation: 1,
+            blueCarbonProjectPlanning: 1,
+            establishingCarbonRights: 1,
+            validation: 1,
+            implementationLabor: 1,
+            monitoring: 1,
+            maintenance: 1,
+            communityBenefitSharingFund: 1,
+            carbonStandardFees: 1,
+            baselineReassessment: 1,
+            mrv: 1,
+            longTermProjectOperatingCost: 1,
+            financingCost: 1,
           },
         });
       const errorTitles = response.body.errors.map((error) => error.title);
@@ -150,6 +226,32 @@ describe('Create Custom Projects - Request Validations', () => {
             lossRateUsed: 'National average',
             emissionFactorUsed: PROJECT_EMISSION_FACTORS.TIER_3,
             projectSpecificEmission: 'One emission factor',
+          },
+          assumptions: {
+            verificationFrequency: 1,
+            baselineReassessmentFrequency: 1,
+            discountRate: 1,
+            carbonPriceIncrease: 1,
+            buffer: 1,
+            projectLength: 1,
+          },
+          costInputs: {
+            feasibilityAnalysis: 1,
+            conservationPlanningAndAdmin: 1,
+            dataCollectionAndFieldCost: 1,
+            communityRepresentation: 1,
+            blueCarbonProjectPlanning: 1,
+            establishingCarbonRights: 1,
+            validation: 1,
+            implementationLabor: 1,
+            monitoring: 1,
+            maintenance: 1,
+            communityBenefitSharingFund: 1,
+            carbonStandardFees: 1,
+            baselineReassessment: 1,
+            mrv: 1,
+            longTermProjectOperatingCost: 1,
+            financingCost: 1,
           },
         });
       const errorTitles = response.body.errors.map((error) => error.title);

--- a/client/src/containers/projects/form/setup/index.tsx
+++ b/client/src/containers/projects/form/setup/index.tsx
@@ -48,7 +48,20 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export type CustomProjectForm = z.infer<typeof CreateCustomProjectSchema>;
+export type ValidatedCustomProjectForm = z.infer<
+  typeof CreateCustomProjectSchema
+>;
+export type CustomProjectForm = Omit<
+  ValidatedCustomProjectForm,
+  "costInputs" | "assumptions"
+> & {
+  costInputs?: {
+    [K in keyof ValidatedCustomProjectForm["costInputs"]]: number | undefined;
+  };
+  assumptions?: {
+    [K in keyof ValidatedCustomProjectForm["assumptions"]]: number | undefined;
+  };
+};
 
 export default function SetupProjectForm() {
   const { queryKey } = queryKeys.customProjects.countries;

--- a/client/src/containers/projects/form/utils.ts
+++ b/client/src/containers/projects/form/utils.ts
@@ -23,9 +23,14 @@ import {
   DEFAULT_RESTORATION_FORM_VALUES,
 } from "@/containers/projects/form/constants";
 import { RestorationPlanFormProperty } from "@/containers/projects/form/restoration-plan/columns";
-import { CustomProjectForm } from "@/containers/projects/form/setup";
+import {
+  CustomProjectForm,
+  ValidatedCustomProjectForm,
+} from "@/containers/projects/form/setup";
 
-export const parseFormValues = (data: CustomProjectForm) => {
+export const parseFormValues = (
+  data: CustomProjectForm,
+): ValidatedCustomProjectForm => {
   const queryClient = getQueryClient();
 
   const originalValues = { ...data };
@@ -46,7 +51,10 @@ export const parseFormValues = (data: CustomProjectForm) => {
       activity: data.activity,
       countryCode: data.countryCode,
       ...(data.activity === ACTIVITY.RESTORATION && {
-        restorationActivity: data.parameters?.restorationActivity,
+        restorationActivity:
+          "restorationActivity" in data.parameters
+            ? data.parameters.restorationActivity
+            : undefined,
       }),
     }).queryKey,
   );
@@ -130,7 +138,7 @@ export const parseFormValues = (data: CustomProjectForm) => {
         };
       }, {}),
     },
-  };
+  } as unknown as ValidatedCustomProjectForm;
 };
 
 /**
@@ -269,7 +277,7 @@ export const useDefaultFormValues = (id?: string): CustomProjectForm => {
 };
 
 export const updateCustomProject = async (options: {
-  body: CustomProjectForm;
+  body: ValidatedCustomProjectForm;
   params: { id: string };
   extraHeaders:
     | {
@@ -294,7 +302,7 @@ export const updateCustomProject = async (options: {
 };
 
 export const createCustomProject = async (options: {
-  body: CustomProjectForm;
+  body: ValidatedCustomProjectForm;
 }): Promise<ApiResponse<CustomProject>> => {
   try {
     const { status, body } =

--- a/shared/lib/stubs/custom-project.stub.ts
+++ b/shared/lib/stubs/custom-project.stub.ts
@@ -5,9 +5,8 @@ import {
   CustomProject,
 } from "@shared/entities/custom-project.entity";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
-import {LOSS_RATE_USED} from "@shared/schemas/custom-projects/create-custom-project.schema";
-import {EMISSION_FACTORS_TIER_TYPES} from "@shared/entities/carbon-inputs/emission-factors.entity";
-
+import { LOSS_RATE_USED } from "@shared/schemas/custom-projects/create-custom-project.schema";
+import { EMISSION_FACTORS_TIER_TYPES } from "@shared/entities/carbon-inputs/emission-factors.entity";
 
 // TODO: research why this breaks in emission factors
 const DEFAULT_CONSERVATION_CUSTOM_PROJECT: CustomProject | any = {
@@ -706,7 +705,7 @@ const DEFAULT_CONSERVATION_CUSTOM_PROJECT: CustomProject | any = {
       verificationFrequency: 5,
       baselineReassessmentFrequency: 10,
       discountRate: 0.04,
-      restorationRate: 250,
+      // restorationRate: 250,
       carbonPriceIncrease: 0.015,
       buffer: 0.2,
       projectLength: 20,


### PR DESCRIPTION
This pull request focuses on enhancing the validation and schema definitions for creating custom projects. The changes ensure that required fields are properly validated and that the schemas enforce the presence of necessary data.

### Validation Improvements:

* Added validation checks for missing required fields in custom project creation tests. These checks include `assumptions`, `costInputs`, and specific parameters within the project-specific emission factors. [[1]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012R55-R83) [[2]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012R127-L106) [[3]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012R177-R203) [[4]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012R230-R256)

### Schema Updates:

* Updated `AssumptionsSchema` and `InputCostsSchema` to make all fields mandatory, ensuring that all necessary data is provided during custom project creation. [[1]](diffhunk://#diff-e2acc2e0e44826a98602752f24e3062f9cfd0526a60190ad2f8b02d0127fdbf0L77-R86) [[2]](diffhunk://#diff-e2acc2e0e44826a98602752f24e3062f9cfd0526a60190ad2f8b02d0127fdbf0L99-R132)
* Modified `CustomProjectBaseSchema` to require `assumptions` and `costInputs` fields, removing the optional flag.