### PR TITLE
fix: form validation create-custom-project

### DIFF
--- a/client/src/containers/projects/form/header.tsx
+++ b/client/src/containers/projects/form/header.tsx
@@ -4,6 +4,7 @@ import { useFormContext } from "react-hook-form";
 
 import { useRouter } from "next/navigation";
 
+import { CreateCustomProjectSchema } from "@shared/schemas/custom-projects/create-custom-project.schema";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
@@ -13,9 +14,9 @@ import { getAuthHeader } from "@/lib/utils";
 import { CustomProjectForm } from "@/containers/projects/form/setup";
 import {
   createCustomProject,
-  parseFormValues,
   updateCustomProject,
 } from "@/containers/projects/form/utils";
+import parseFormValues from "@/containers/projects/form/utils/parse-form-values";
 
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
@@ -37,6 +38,18 @@ export default function Header({ name, id }: HeaderProps) {
     async (data: CustomProjectForm) => {
       try {
         const formValues = parseFormValues(data);
+        const result = CreateCustomProjectSchema.safeParse(formValues);
+
+        if (!result.success) {
+          // Set errors for each field that failed validation
+          result.error.errors.forEach((error) => {
+            methods.setError(error.path.join(".") as keyof CustomProjectForm, {
+              type: "custom",
+              message: error.message,
+            });
+          });
+          return;
+        }
 
         if (isEdit) {
           await updateCustomProject({
@@ -68,7 +81,7 @@ export default function Header({ name, id }: HeaderProps) {
         });
       }
     },
-    [id, session, router, queryClient, isEdit, toast],
+    [id, session, router, queryClient, isEdit, toast, methods],
   );
 
   return (

--- a/client/src/containers/projects/form/index.tsx
+++ b/client/src/containers/projects/form/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CreateCustomProjectSchema } from "@shared/schemas/custom-projects/create-custom-project.schema";
+import { CustomProjectFormSchema } from "@shared/schemas/custom-projects/custom-project-form.schema";
 import { ExtractAtomValue, useSetAtom } from "jotai";
 
 import Header from "@/containers/projects/form/header";
@@ -27,7 +27,7 @@ export default function CustomProjectForm({ id }: CustomProjectFormProps) {
 
   const formValues = useDefaultFormValues(id);
   const methods = useForm<CustomProjectForm>({
-    resolver: zodResolver(CreateCustomProjectSchema),
+    resolver: zodResolver(CustomProjectFormSchema),
     defaultValues: formValues,
     mode: "all",
   });

--- a/client/src/containers/projects/form/utils/parse-form-values.ts
+++ b/client/src/containers/projects/form/utils/parse-form-values.ts
@@ -1,0 +1,173 @@
+// Default values to satisfy TypeScript requirements for form validation
+
+import { ACTIVITY } from "@shared/entities/activity.enum";
+import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
+import { ASSUMPTIONS_NAME_TO_DTO_MAP } from "@shared/schemas/assumptions/assumptions.enums";
+
+import { client } from "@/lib/query-client";
+import { queryKeys } from "@/lib/query-keys";
+
+import { getQueryClient } from "@/app/providers";
+
+import {
+  CustomProjectForm,
+  ValidatedCustomProjectForm,
+} from "@/containers/projects/form/setup";
+
+// These will be overridden by actual values from the API or user input
+const DEFAULT_COST_INPUTS = {
+  validation: 0,
+  feasibilityAnalysis: 0,
+  conservationPlanningAndAdmin: 0,
+  dataCollectionAndFieldCost: 0,
+  communityRepresentation: 0,
+  blueCarbonProjectPlanning: 0,
+  establishingCarbonRights: 0,
+  implementationLabor: 0,
+  equipmentAndMaterials: 0,
+  maintenance: 0,
+  monitoring: 0,
+  verification: 0,
+  certification: 0,
+  projectManagement: 0,
+  communityBenefitSharingFund: 0,
+  registryFees: 0,
+  brokerage: 0,
+  insuranceCost: 0,
+  financingCost: 0,
+  carbonStandardFees: 0,
+  baselineReassessment: 0,
+  mrv: 0,
+  longTermProjectOperatingCost: 0,
+} as const;
+
+const DEFAULT_ASSUMPTIONS = {
+  baselineReassessmentFrequency: 0,
+  buffer: 0,
+  carbonPriceIncrease: 0,
+  discountRate: 0,
+  verificationFrequency: 0,
+  projectLength: 0,
+} as const;
+
+const getDefaultAssumptions = (ecosystem: ECOSYSTEM, activity: ACTIVITY) => {
+  const queryClient = getQueryClient();
+
+  return client.customProjects.getDefaultAssumptions
+    .getQueryData(
+      queryClient,
+      queryKeys.customProjects.assumptions({
+        ecosystem: ecosystem,
+        activity: activity,
+      }).queryKey,
+    )
+    ?.body.data.reduce((acc, { name, value }) => {
+      return {
+        ...acc,
+        [ASSUMPTIONS_NAME_TO_DTO_MAP[
+          name as keyof typeof ASSUMPTIONS_NAME_TO_DTO_MAP
+        ]]: Number(value as NonNullable<typeof value>),
+      };
+    }, {});
+};
+
+const getDefaultCostInputs = (data: CustomProjectForm) => {
+  const { ecosystem, activity, countryCode } = data;
+  const queryClient = getQueryClient();
+
+  return client.customProjects.getDefaultCostInputs.getQueryData(
+    queryClient,
+    queryKeys.customProjects.defaultCosts({
+      ecosystem: ecosystem,
+      activity: activity,
+      countryCode: countryCode,
+      ...(activity === ACTIVITY.RESTORATION && {
+        restorationActivity:
+          "restorationActivity" in data.parameters
+            ? data.parameters.restorationActivity
+            : undefined,
+      }),
+    }).queryKey,
+  )?.body.data;
+};
+
+const parseFormValues = (
+  data: CustomProjectForm,
+): ValidatedCustomProjectForm => {
+  const originalValues = { ...data };
+  const defaultAssumptions = getDefaultAssumptions(
+    data.ecosystem,
+    data.activity,
+  );
+  const costs = getDefaultCostInputs(data);
+  const isRestoration = data.activity === ACTIVITY.RESTORATION;
+
+  const validYears = isRestoration // @ts-expect-error fix later
+    ? (originalValues.parameters.restorationYearlyBreakdown as number[])
+        .map((v, index) => ({
+          year: index == 0 ? -1 : index,
+          hectares: v,
+        }))
+        .filter((v) => v.hectares > 0)
+    : [];
+
+  const {
+    // @ts-expect-error fix later
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    restorationYearlyBreakdown,
+    ...restParameters
+  } = originalValues.parameters;
+
+  return {
+    ...originalValues,
+    parameters: {
+      ...restParameters,
+      // @ts-expect-error fix later
+      ...(restParameters?.plantingSuccessRate && {
+        plantingSuccessRate:
+          // @ts-expect-error fix later
+          restParameters.plantingSuccessRate / 100,
+      }),
+      ...(isRestoration && {
+        ...(validYears.length > 0 && {
+          restorationYearlyBreakdown: validYears.map(({ year, hectares }) => ({
+            year,
+            annualHectaresRestored: hectares,
+          })),
+        }),
+      }),
+    },
+    assumptions: {
+      ...DEFAULT_ASSUMPTIONS,
+      ...Object.keys(originalValues.assumptions ?? {}).reduce(
+        (acc, assumptionKey) => {
+          return {
+            ...acc,
+            [assumptionKey]:
+              originalValues.assumptions?.[
+                assumptionKey as keyof typeof originalValues.assumptions
+              ] ??
+              defaultAssumptions?.[
+                assumptionKey as keyof typeof defaultAssumptions
+              ],
+          };
+        },
+        {},
+      ),
+    },
+    costInputs: {
+      ...DEFAULT_COST_INPUTS,
+      ...Object.keys(originalValues.costInputs ?? {}).reduce((acc, costKey) => {
+        return {
+          ...acc,
+          [costKey]:
+            originalValues.costInputs?.[
+              costKey as keyof typeof originalValues.costInputs
+            ] ?? costs?.[costKey as keyof typeof costs],
+        };
+      }, {}),
+    },
+  };
+};
+
+export default parseFormValues;

--- a/shared/schemas/custom-projects/create-custom-project.schema.ts
+++ b/shared/schemas/custom-projects/create-custom-project.schema.ts
@@ -172,7 +172,7 @@ export const CustomProjectBaseLooseSchema = CustomProjectBaseSchema.extend({
 });
 
 // Complex validations that depend on multiple fields
-const ValidateConservationSchema = (
+export const ValidateConservationSchema = (
   data: z.infer<typeof CreateCustomProjectSchema>,
   ctx: z.RefinementCtx,
 ) => {
@@ -247,7 +247,7 @@ const ValidateConservationSchema = (
 };
 
 // Complex validations that depend on multiple fields
-const ValidateRestorationSchema = (
+export const ValidateRestorationSchema = (
   data: z.infer<typeof CreateCustomProjectSchema>,
   ctx: z.RefinementCtx,
 ) => {

--- a/shared/schemas/custom-projects/custom-project-form.schema.ts
+++ b/shared/schemas/custom-projects/custom-project-form.schema.ts
@@ -1,0 +1,64 @@
+import { ACTIVITY } from "@shared/entities/activity.enum";
+import {
+  ConservationCustomProjectSchema,
+  RestorationCustomProjectSchema,
+  CreateCustomProjectSchema,
+  CustomProjectBaseLooseSchema,
+  ValidateConservationSchema,
+  ValidateRestorationSchema,
+} from "@shared/schemas/custom-projects/create-custom-project.schema";
+import { z } from "zod";
+
+const ConservationCustomProjectFormSchema =
+  ConservationCustomProjectSchema.partial();
+
+const RestorationCustomProjectFormSchema =
+  RestorationCustomProjectSchema.partial();
+
+const ValidateLooseConservationSchema = (
+  data: z.infer<typeof CustomProjectFormSchema>,
+  ctx: z.RefinementCtx,
+) => {
+  if (data.parameters)
+    ValidateConservationSchema(
+      data as z.infer<typeof CreateCustomProjectSchema>,
+      ctx,
+    );
+};
+
+const ValidateLooseRestorationSchema = (
+  data: z.infer<typeof CustomProjectFormSchema>,
+  ctx: z.RefinementCtx,
+) => {
+  if (data.parameters)
+    ValidateRestorationSchema(
+      data as z.infer<typeof CreateCustomProjectSchema>,
+      ctx,
+    );
+};
+
+/**
+ * Looser schema derived from the CreateCustomProjectSchema
+ */
+const CustomProjectFormSchema = z
+  .discriminatedUnion("activity", [
+    z.object({
+      ...CustomProjectBaseLooseSchema.shape,
+      activity: z.literal(ACTIVITY.CONSERVATION),
+      parameters: ConservationCustomProjectFormSchema.optional(),
+    }),
+    z.object({
+      ...CustomProjectBaseLooseSchema.shape,
+      activity: z.literal(ACTIVITY.RESTORATION),
+      parameters: RestorationCustomProjectFormSchema.optional(),
+    }),
+  ])
+  .superRefine((data, ctx) => {
+    if (data.activity === ACTIVITY.CONSERVATION) {
+      ValidateLooseConservationSchema(data, ctx);
+    } else if (data.activity === ACTIVITY.RESTORATION) {
+      ValidateLooseRestorationSchema(data, ctx);
+    }
+  });
+
+export { CustomProjectFormSchema };


### PR DESCRIPTION
## Changes

- Moved `parseFormValues` to its own file for better organization
- Added explicit validation using `CreateCustomProjectSchema.safeParse()` in the form header
- Updated schema imports to use the new `CustomProjectFormSchema`
- Strict error handling by setting field-specific errors when validation fails
