### PR TITLE
fix(api): Scorecard rating number/string convertion based on each field

### DIFF
--- a/api/src/modules/import/services/entity.preprocessor.ts
+++ b/api/src/modules/import/services/entity.preprocessor.ts
@@ -73,6 +73,14 @@ import {
   RecordSource,
   RecordWithSources,
 } from '@api/modules/import/services/parsed-db-entities.type';
+import { LegalFeasibility } from '@shared/entities/project-score-card/value-object/legal-feasibility.value-object';
+import { ImplementationFeasibility } from '@shared/entities/project-score-card/value-object/implementation-feasibility.value-object';
+import { SocialFeasibility } from '@shared/entities/project-score-card/value-object/social-feasibility.value-object';
+import { SecurityRating } from '@shared/entities/project-score-card/value-object/security-rating.value-object';
+import { AvailabilityOfExperiencedLabor } from '@shared/entities/project-score-card/value-object/availability-of-experienced-labor.value-object';
+import { AvailabilityOfAlternatingFunding } from '@shared/entities/project-score-card/value-object/availability-of-alternating-funding.value-object';
+import { CoastalProtectionBenefits } from '@shared/entities/project-score-card/value-object/coastal-protection-benefits.value-object';
+import { BiodiversityBenefit } from '@shared/entities/project-score-card/value-object/biodiversity-benefit.value-object';
 
 export class ProjectScoreCardNotFoundError extends Error {
   constructor(projectName: string) {
@@ -1049,51 +1057,45 @@ export class EntityPreprocessor {
       projectScorecard.countryCode = row.country_code;
       projectScorecard.ecosystem = row.ecosystem;
       projectScorecard.financialFeasibility = PROJECT_SCORE.LOW;
-      projectScorecard.legalFeasibility = this.convertNumberToProjectScore(
+      projectScorecard.legalFeasibility = LegalFeasibility.fromNumber(
         row.legal_feasibility,
-      );
+      ).toProjectScore();
 
       projectScorecard.implementationFeasibility =
-        this.convertNumberToProjectScore(row.implementation_risk_score);
+        ImplementationFeasibility.fromNumber(
+          row.implementation_risk_score,
+        ).toProjectScore();
 
-      projectScorecard.socialFeasibility = this.convertNumberToProjectScore(
+      projectScorecard.socialFeasibility = SocialFeasibility.fromNumber(
         row.social_feasibility,
-      );
+      ).toProjectScore();
 
-      projectScorecard.securityRating = this.convertNumberToProjectScore(
+      projectScorecard.securityRating = SecurityRating.fromNumber(
         row.security_rating,
-      );
+      ).toProjectScore();
 
       projectScorecard.availabilityOfExperiencedLabor =
-        this.convertNumberToProjectScore(row.availability_of_experienced_labor);
+        AvailabilityOfExperiencedLabor.fromNumber(
+          row.availability_of_experienced_labor,
+        ).toProjectScore();
 
       projectScorecard.availabilityOfAlternatingFunding =
-        this.convertNumberToProjectScore(
+        AvailabilityOfAlternatingFunding.fromNumber(
           row.availability_of_alternative_funding,
-        );
+        ).toProjectScore();
 
       projectScorecard.coastalProtectionBenefits =
-        this.convertNumberToProjectScore(row.coastal_protection_benefit);
-      projectScorecard.biodiversityBenefit = this.convertNumberToProjectScore(
+        CoastalProtectionBenefits.fromNumber(
+          row.coastal_protection_benefit,
+        ).toProjectScore();
+      projectScorecard.biodiversityBenefit = BiodiversityBenefit.fromNumber(
         row.biodiversity_benefit,
-      );
+      ).toProjectScore();
 
       parsedArray.push(projectScorecard);
     });
 
     return parsedArray;
-  }
-
-  private convertNumberToProjectScore(value: number): PROJECT_SCORE {
-    if (value === 1) {
-      return PROJECT_SCORE.LOW;
-    }
-    if (value === 2) {
-      return PROJECT_SCORE.MEDIUM;
-    }
-    if (value === 3) {
-      return PROJECT_SCORE.HIGH;
-    }
   }
 
   private emptyStringToNull(value: any): any | null {

--- a/shared/entities/project-score-card/value-object/availability-of-alternating-funding.value-object.ts
+++ b/shared/entities/project-score-card/value-object/availability-of-alternating-funding.value-object.ts
@@ -1,0 +1,35 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class AvailabilityOfAlternatingFunding extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): AvailabilityOfAlternatingFunding {
+    return new AvailabilityOfAlternatingFunding(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): AvailabilityOfAlternatingFunding {
+    return new AvailabilityOfAlternatingFunding(
+      AvailabilityOfAlternatingFunding.NUMBER_TO_STRING_MAP[value],
+    );
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return (
+      AvailabilityOfAlternatingFunding.STRING_TO_NUMBER_MAP[this.value] ?? 0
+    );
+  }
+}

--- a/shared/entities/project-score-card/value-object/availability-of-experienced-labor.value-object.ts
+++ b/shared/entities/project-score-card/value-object/availability-of-experienced-labor.value-object.ts
@@ -1,0 +1,33 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class AvailabilityOfExperiencedLabor extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): AvailabilityOfExperiencedLabor {
+    return new AvailabilityOfExperiencedLabor(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): AvailabilityOfExperiencedLabor {
+    return new AvailabilityOfExperiencedLabor(
+      AvailabilityOfExperiencedLabor.NUMBER_TO_STRING_MAP[value],
+    );
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return AvailabilityOfExperiencedLabor.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/biodiversity-benefit.value-object.ts
+++ b/shared/entities/project-score-card/value-object/biodiversity-benefit.value-object.ts
@@ -1,0 +1,33 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class BiodiversityBenefit extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): BiodiversityBenefit {
+    return new BiodiversityBenefit(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): BiodiversityBenefit {
+    return new BiodiversityBenefit(
+      BiodiversityBenefit.NUMBER_TO_STRING_MAP[value],
+    );
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return BiodiversityBenefit.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/coastal-protection-benefits.value-object.ts
+++ b/shared/entities/project-score-card/value-object/coastal-protection-benefits.value-object.ts
@@ -1,0 +1,33 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class CoastalProtectionBenefits extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): CoastalProtectionBenefits {
+    return new CoastalProtectionBenefits(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): CoastalProtectionBenefits {
+    return new CoastalProtectionBenefits(
+      CoastalProtectionBenefits.NUMBER_TO_STRING_MAP[value],
+    );
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return CoastalProtectionBenefits.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/finantial-feasability.value-object.ts
+++ b/shared/entities/project-score-card/value-object/finantial-feasability.value-object.ts
@@ -1,0 +1,33 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class FinantialFeasibility extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.LOW,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.HIGH,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.LOW]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.HIGH]: 3,
+  };
+
+  public static fromString(value: string): FinantialFeasibility {
+    return new FinantialFeasibility(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): FinantialFeasibility {
+    return new FinantialFeasibility(
+      FinantialFeasibility.NUMBER_TO_STRING_MAP[value],
+    );
+  }
+
+  public toStringOrUndefined(): string | undefined {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return FinantialFeasibility.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/implementation-feasibility.value-object.ts
+++ b/shared/entities/project-score-card/value-object/implementation-feasibility.value-object.ts
@@ -1,0 +1,33 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class ImplementationFeasibility extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): ImplementationFeasibility {
+    return new ImplementationFeasibility(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): ImplementationFeasibility {
+    return new ImplementationFeasibility(
+      ImplementationFeasibility.NUMBER_TO_STRING_MAP[value],
+    );
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return ImplementationFeasibility.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/legal-feasibility.value-object.ts
+++ b/shared/entities/project-score-card/value-object/legal-feasibility.value-object.ts
@@ -1,0 +1,31 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class LegalFeasibility extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): LegalFeasibility {
+    return new LegalFeasibility(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): LegalFeasibility {
+    return new LegalFeasibility(LegalFeasibility.NUMBER_TO_STRING_MAP[value]);
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return LegalFeasibility.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/project-score-card-field.value-object.ts
+++ b/shared/entities/project-score-card/value-object/project-score-card-field.value-object.ts
@@ -1,0 +1,25 @@
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export abstract class ProjectScoreCardField {
+  protected readonly value: PROJECT_SCORE;
+
+  protected constructor(value: PROJECT_SCORE) {
+    this.value = value;
+  }
+
+  public static fromString(value: string): ProjectScoreCardField {
+    throw new Error("Method not implemented.");
+  }
+
+  public static fromNumber(value: number): ProjectScoreCardField {
+    throw new Error("Method not implemented.");
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    throw new Error("Method not implemented.");
+  }
+
+  public toNumber(): number {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/shared/entities/project-score-card/value-object/security-rating.value-object.ts
+++ b/shared/entities/project-score-card/value-object/security-rating.value-object.ts
@@ -1,0 +1,31 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class SecurityRating extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): SecurityRating {
+    return new SecurityRating(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): SecurityRating {
+    return new SecurityRating(SecurityRating.NUMBER_TO_STRING_MAP[value]);
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return SecurityRating.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score-card/value-object/social-feasibility.value-object.ts
+++ b/shared/entities/project-score-card/value-object/social-feasibility.value-object.ts
@@ -1,0 +1,31 @@
+import { ProjectScoreCardField } from "@shared/entities/project-score-card/value-object/project-score-card-field.value-object";
+import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
+
+export class SocialFeasibility extends ProjectScoreCardField {
+  private static NUMBER_TO_STRING_MAP: Record<number, PROJECT_SCORE> = {
+    1: PROJECT_SCORE.HIGH,
+    2: PROJECT_SCORE.MEDIUM,
+    3: PROJECT_SCORE.LOW,
+  };
+  private static STRING_TO_NUMBER_MAP: Record<PROJECT_SCORE, number> = {
+    [PROJECT_SCORE.HIGH]: 1,
+    [PROJECT_SCORE.MEDIUM]: 2,
+    [PROJECT_SCORE.LOW]: 3,
+  };
+
+  public static fromString(value: string): SocialFeasibility {
+    return new SocialFeasibility(value as PROJECT_SCORE);
+  }
+
+  public static fromNumber(value: number): SocialFeasibility {
+    return new SocialFeasibility(SocialFeasibility.NUMBER_TO_STRING_MAP[value]);
+  }
+
+  public toProjectScore(): PROJECT_SCORE {
+    return this.value;
+  }
+
+  public toNumber(): number {
+    return SocialFeasibility.STRING_TO_NUMBER_MAP[this.value] ?? 0;
+  }
+}

--- a/shared/entities/project-score.utils.ts
+++ b/shared/entities/project-score.utils.ts
@@ -1,46 +1,47 @@
+import { AvailabilityOfAlternatingFunding } from "@shared/entities/project-score-card/value-object/availability-of-alternating-funding.value-object";
+import { AvailabilityOfExperiencedLabor } from "@shared/entities/project-score-card/value-object/availability-of-experienced-labor.value-object";
+import { BiodiversityBenefit } from "@shared/entities/project-score-card/value-object/biodiversity-benefit.value-object";
+import { CoastalProtectionBenefits } from "@shared/entities/project-score-card/value-object/coastal-protection-benefits.value-object";
+import { ImplementationFeasibility } from "@shared/entities/project-score-card/value-object/implementation-feasibility.value-object";
+import { LegalFeasibility } from "@shared/entities/project-score-card/value-object/legal-feasibility.value-object";
+import { SecurityRating } from "@shared/entities/project-score-card/value-object/security-rating.value-object";
+import { SocialFeasibility } from "@shared/entities/project-score-card/value-object/social-feasibility.value-object";
 import { PROJECT_SCORE } from "@shared/entities/project-score.enum";
 import { ProjectScorecard } from "@shared/entities/project-scorecard.entity";
 
 export const ProjectScoreUtils = {
-  toNumber: (score: PROJECT_SCORE): number => {
-    switch (score) {
-      case PROJECT_SCORE.LOW:
-        return 1;
-      case PROJECT_SCORE.MEDIUM:
-        return 2;
-      case PROJECT_SCORE.HIGH:
-        return 3;
-      default:
-        return 0;
-    }
-  },
   computeProjectScoreCardRating(
     projectScoreCard: ProjectScorecard,
   ): PROJECT_SCORE | null {
-    const legalFeasibility = ProjectScoreUtils.toNumber(
+    const legalFeasibility = LegalFeasibility.fromString(
       projectScoreCard.legalFeasibility,
-    );
-    const implementationFeasibility = ProjectScoreUtils.toNumber(
+    ).toNumber();
+
+    const implementationFeasibility = ImplementationFeasibility.fromString(
       projectScoreCard.implementationFeasibility,
-    );
-    const socialFeasibility = ProjectScoreUtils.toNumber(
+    ).toNumber();
+
+    const socialFeasibility = SocialFeasibility.fromString(
       projectScoreCard.socialFeasibility,
-    );
-    const securityRating = ProjectScoreUtils.toNumber(
+    ).toNumber();
+
+    const securityRating = SecurityRating.fromString(
       projectScoreCard.securityRating,
-    );
-    const availabilityOfExperiencedLabor = ProjectScoreUtils.toNumber(
-      projectScoreCard.availabilityOfExperiencedLabor,
-    );
-    const availabilityOfAlternatingFunding = ProjectScoreUtils.toNumber(
-      projectScoreCard.availabilityOfAlternatingFunding,
-    );
-    const coastalProtectionBenefits = ProjectScoreUtils.toNumber(
+    ).toNumber();
+    const availabilityOfExperiencedLabor =
+      AvailabilityOfExperiencedLabor.fromString(
+        projectScoreCard.availabilityOfExperiencedLabor,
+      ).toNumber();
+    const availabilityOfAlternatingFunding =
+      AvailabilityOfAlternatingFunding.fromString(
+        projectScoreCard.availabilityOfAlternatingFunding,
+      ).toNumber();
+    const coastalProtectionBenefits = CoastalProtectionBenefits.fromString(
       projectScoreCard.coastalProtectionBenefits,
-    );
-    const biodiversityBenefit = ProjectScoreUtils.toNumber(
+    ).toNumber();
+    const biodiversityBenefit = BiodiversityBenefit.fromString(
       projectScoreCard.biodiversityBenefit,
-    );
+    ).toNumber();
 
     const scoreCardRating: number =
       (legalFeasibility * 0.12 +


### PR DESCRIPTION
This pull request introduces a significant refactor of the project scorecard system by replacing the `convertNumberToProjectScore` method with dedicated value object classes for each scorecard field. The changes include modifications to the `EntityPreprocessor` class and the addition of several new value object classes.

### Changes to `EntityPreprocessor`:

* Replaced `convertNumberToProjectScore` method calls with corresponding value object method calls for various project scorecard fields.
* Removed the `convertNumberToProjectScore` method as it is no longer needed.

### New Value Object Classes:

* Added `AvailabilityOfAlternatingFunding` class to handle conversion between numbers and project scores.
* Added `AvailabilityOfExperiencedLabor` class to handle conversion between numbers and project scores.
* Added `BiodiversityBenefit` class to handle conversion between numbers and project scores.
* Added `CoastalProtectionBenefits` class to handle conversion between numbers and project scores.
* Added `FinantialFeasibility` class to handle conversion between numbers and project scores.
* Added `ImplementationFeasibility` class to handle conversion between numbers and project scores.
* Added `LegalFeasibility` class to handle conversion between numbers and project scores.
* Added `SecurityRating` class to handle conversion between numbers and project scores.
* Added `SocialFeasibility` class to handle conversion between numbers and project scores.

### Utility Updates:

* Updated `ProjectScoreUtils` to use the new value object classes for score conversion.