### PR TITLE
[TBCCT-237] Add back button to navigate to the front office

### DIFF
--- a/backoffice/components/dashboard.tsx
+++ b/backoffice/components/dashboard.tsx
@@ -1,4 +1,5 @@
-import { Box, H1, Text } from "@adminjs/design-system";
+import React from 'react';
+import { Box, H1, Text } from '@adminjs/design-system';
 
 const Dashboard = () => {
   return (

--- a/backoffice/index.ts
+++ b/backoffice/index.ts
@@ -44,6 +44,7 @@ import { CountryResource } from './resources/countries/country.resource.js';
 import { componentLoader, Components } from 'backoffice/components/index.js';
 import { ModelComponentSourceResource } from 'backoffice/resources/model-component-source/model-component-source.resource.js';
 import { EcosystemExtentResource } from 'backoffice/resources/ecosystem-extent/ecosystem-extent.resource.js';
+import path from 'path';
 
 AdminJS.registerAdapter({
   Database: AdminJSTypeorm.Database,
@@ -52,6 +53,7 @@ AdminJS.registerAdapter({
 
 const PORT = 1000;
 export const API_URL = process.env.API_URL || 'http://localhost:4000';
+const ROOT_PATH = '/admin';
 const authProvider = new AuthProvider();
 
 const start = async () => {
@@ -87,7 +89,11 @@ const start = async () => {
     dashboard: {
       component: Components.Dashboard,
     },
-    rootPath: '/admin',
+    assets: {
+      styles: [`${ROOT_PATH}/public/back-button.css`],
+      scripts: [`${ROOT_PATH}/public/back-button.js`],
+    },
+    rootPath: ROOT_PATH,
     componentLoader,
     resources: [
       UserResource,
@@ -230,6 +236,7 @@ const start = async () => {
     },
   );
 
+  app.use(`${ROOT_PATH}/public`, express.static(path.join('.', 'public')));
   app.use(admin.options.rootPath, adminRouter);
   admin.watch();
   app.listen(PORT, () => {

--- a/backoffice/public/back-button.css
+++ b/backoffice/public/back-button.css
@@ -1,0 +1,31 @@
+[data-css='sidebar-logo'] {
+  text-align: left !important;
+  display: inline !important;
+  padding: 20px 40px 5px !important;
+}
+
+[data-css='sidebar-back-button'] {
+  color: rgba(0, 0, 0, 0.8) !important;
+  text-decoration: none !important;
+  margin-bottom: 5px;
+  padding-left: 40px;
+  padding-right: 15px;
+  display: flex;
+  align-items: center;
+}
+
+[data-css='sidebar-back-button'] span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
+  padding: 2px;
+  margin-right: 6px;
+  color: rgba(0, 0, 0, 0.8) !important;
+  text-decoration: none !important;
+}
+
+[data-css='sidebar-back-button']:hover {
+  cursor: pointer;
+}

--- a/backoffice/public/back-button.js
+++ b/backoffice/public/back-button.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  addBackButton();
+});
+
+// This is a fix as AdminJS can behave as an SPA and 'DOMContentLoaded' is not triggered but we still want to display the logo
+const intervalId = setInterval(() => {
+  if (!addBackButton()) {
+    clearInterval(intervalId);
+  }
+}, 300);
+
+const addBackButton = () => {
+  if (document.querySelector('[data-css="sidebar-back-button"]')) {
+    return;
+  }
+
+  const logoElement = document.querySelector('[data-css="sidebar-logo"]');
+  if (logoElement) {
+    const backButton = document.createElement('a');
+    backButton.dataset.css = 'sidebar-back-button';
+    backButton.href = window.location.origin; // Replace with your frontend URL
+
+    const iconSpan = document.createElement('span');
+    iconSpan.innerHTML = `
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="15 18 9 12 15 6"></polyline>
+          </svg>
+        `;
+
+    const textNode = document.createTextNode('Back to the tool');
+    backButton.appendChild(iconSpan);
+    backButton.appendChild(textNode);
+    logoElement.insertAdjacentElement('afterend', backButton);
+    return backButton;
+  }
+};


### PR DESCRIPTION
This pull request includes several changes to the back office dashboard, including the addition of a back button and updates to the root path configuration. The most important changes are grouped into two themes: codebase improvements and UI enhancements.

### Codebase Improvements:
* [`backoffice/index.ts`](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R47): Added `path` import and updated the `start` function to include a new `ROOT_PATH` constant. This constant is used to define the root path for assets and static files. [[1]](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R47) [[2]](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R56) [[3]](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405L90-R96) [[4]](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R239)
* [`backoffice/components/dashboard.tsx`](diffhunk://#diff-ee93c288475bfd87cc412c727430fa3f66a850ae74ceb1a265f967a9dd618ac0L1-R2): Added missing `React` import to ensure proper rendering of the dashboard component.

### UI Enhancements:
* [`backoffice/public/back-button.css`](diffhunk://#diff-55308803383c373261b1491e7799f6596902195b9e12b085e3a66c7c5fe1644fR1-R31): Added CSS styles for a new sidebar back button, including styles for alignment, padding, and hover effects.
* [`backoffice/public/back-button.js`](diffhunk://#diff-9da8c4464159ee215014ebf313fbb24438ffb1a92a0a49894d1517b946bfb171R1-R36): Added JavaScript to dynamically create and insert a back button in the sidebar, ensuring it appears even if the page behaves as a single-page application (SPA).