### PR TITLE
[TBCCT-343] Landowner/community benefit share is not correct. 5% instead of 50% and renaming

### DIFF
--- a/api/src/modules/calculations/cost.calculator.ts
+++ b/api/src/modules/calculations/cost.calculator.ts
@@ -234,7 +234,7 @@ export class CostCalculator {
       'Financing cost': financingCost,
       'Funding gap (NPV)': fundingGapNPV,
       'Funding gap per tCO2e (NPV)': fundingGapPerTCO2e,
-      'Community benefit sharing fund': totalCommunityBenefitSharingFund,
+      'Landowner/community benefit share': totalCommunityBenefitSharingFund,
     };
 
     if (

--- a/api/test/integration/calculations/fixtures/conservation-indonesia-mangrove.ts
+++ b/api/test/integration/calculations/fixtures/conservation-indonesia-mangrove.ts
@@ -105,7 +105,7 @@ const CONSERVATION_INDONESIA_MANGROVE_OUTPUT = {
       'Financing cost': 68590,
       'Funding gap (NPV)': 0,
       'Funding gap per tCO2e (NPV)': 0,
-      'Community benefit sharing fund': 0.5,
+      'Landowner/community benefit share': 0.5,
     },
     costDetails: {
       total: {
@@ -946,7 +946,7 @@ const CONSERVATION_INDONESIA_MANGROVE_OUTPUT = {
       'Financing cost': 68590,
       'Funding gap (NPV)': 0,
       'Funding gap per tCO2e (NPV)': 0,
-      'Community benefit sharing fund': 0.5,
+      'Landowner/community benefit share': 0.5,
     },
     costDetails: {
       total: {

--- a/api/test/integration/calculations/fixtures/restoration-china-salt-marsh.ts
+++ b/api/test/integration/calculations/fixtures/restoration-china-salt-marsh.ts
@@ -45,7 +45,7 @@ export const RESTORATION_CHINA_SALT_MARSH = {
       'Funding gap': 25953499,
       'Funding gap (NPV)': 25953499,
       'Funding gap per tCO2e (NPV)': 997.2,
-      'Community benefit sharing fund': 0.5,
+      'Landowner/community benefit share': 0.5,
     },
     costDetails: {
       total: {
@@ -882,7 +882,7 @@ export const RESTORATION_CHINA_SALT_MARSH = {
       'Funding gap': 0,
       'Funding gap (NPV)': 0,
       'Funding gap per tCO2e (NPV)': 0.0,
-      'Community benefit sharing fund': 0.5,
+      'Landowner/community benefit share': 0.5,
     },
     costDetails: {
       total: {

--- a/api/test/integration/calculations/fixtures/restoration-mexico-mangroves.ts
+++ b/api/test/integration/calculations/fixtures/restoration-mexico-mangroves.ts
@@ -159,7 +159,7 @@ const RESTORATION_MEXICO_MANGROVES_OUTPUT = {
       'Financing cost': 468523,
       'Funding gap (NPV)': 9466615,
       'Funding gap per tCO2e (NPV)': 82.8,
-      'Community benefit sharing fund': 0.5,
+      'Landowner/community benefit share': 0.5,
     },
     costDetails: {
       total: {
@@ -994,7 +994,7 @@ const RESTORATION_MEXICO_MANGROVES_OUTPUT = {
       'Financing cost': 468523,
       'Funding gap (NPV)': 0,
       'Funding gap per tCO2e (NPV)': 0.0,
-      'Community benefit sharing fund': 0.5,
+      'Landowner/community benefit share': 0.5,
     },
     costDetails: {
       total: {

--- a/client/src/constants/tooltip.tsx
+++ b/client/src/constants/tooltip.tsx
@@ -677,7 +677,7 @@ export const PROJECT_SUMMARY: Record<keyof CustomProjectSummary, string> = {
     'The reverse of the "NPV covering OPEX" or "NPV covering total cost" metric.',
   "Funding gap per tCO2e (NPV)":
     'The reverse of the "NPV covering OPEX" or "NPV covering total cost" metric.',
-  "Community benefit sharing fund":
+  "Landowner/community benefit share":
     "The percentage of the revenues assumed to go back to the community as part of the community benefit sharing fund.",
   "Net revenue after OPEX": "TODO",
   "Net revenue after Total cost": "TODO",

--- a/client/src/containers/projects/custom-project/index.tsx
+++ b/client/src/containers/projects/custom-project/index.tsx
@@ -81,9 +81,9 @@ const CustomProjectView: FC<{
               "IRR when priced to cover OpEx": parseFloat(
                 toPercentageValue(summaryData["IRR when priced to cover OpEx"]),
               ),
-              "Community benefit sharing fund": parseFloat(
+              "Landowner/community benefit share": parseFloat(
                 toPercentageValue(
-                  summaryData["Community benefit sharing fund"],
+                  summaryData["Landowner/community benefit share"],
                 ),
               ),
             }}

--- a/client/src/containers/projects/custom-project/summary/index.tsx
+++ b/client/src/containers/projects/custom-project/summary/index.tsx
@@ -37,7 +37,7 @@ const customProjectSummaryUnitMap: Record<keyof CustomProjectSummary, string> =
     "Financing cost": "$",
     "Funding gap (NPV)": "$",
     "Funding gap per tCO2e (NPV)": "$",
-    "Community benefit sharing fund": "%",
+    "Landowner/community benefit share": "%",
   } as const;
 interface ProjectSummaryProps {
   data: CustomProjectSummary;

--- a/client/src/hooks/use-custom-project-output.ts
+++ b/client/src/hooks/use-custom-project-output.ts
@@ -106,7 +106,7 @@ export const useCustomProjectOutput = (
         toPercentageValue(output.summary["IRR when priced to cover OpEx"]),
       ),
       "Community benefit sharing fund": parseFloat(
-        toPercentageValue(output.summary["Community benefit sharing fund"]),
+        toPercentageValue(output.summary["Landowner/community benefit share"]),
       ),
     };
   }, [output?.summary]);

--- a/shared/dtos/custom-projects/custom-project-output.dto.ts
+++ b/shared/dtos/custom-projects/custom-project-output.dto.ts
@@ -15,7 +15,7 @@ export type CustomProjectSummary = {
   "Financing cost": number;
   "Funding gap (NPV)": number;
   "Funding gap per tCO2e (NPV)": number;
-  "Community benefit sharing fund": number;
+  "Landowner/community benefit share": number;
   "Net revenue after OPEX": number | undefined;
   "Net revenue after Total cost": number | undefined;
 };
@@ -36,7 +36,7 @@ const SORTED_CUSTOM_PROJECT_SUMMARY_KEYS = [
   "Financing cost",
   "Funding gap (NPV)",
   "Funding gap per tCO2e (NPV)",
-  "Community benefit sharing fund",
+  "Landowner/community benefit share",
 ] as const;
 
 export const sortCustomProjectSummary = (


### PR DESCRIPTION
This pull request includes changes to update the terminology from "Community benefit sharing fund" to "Landowner/community benefit share" across various files in the codebase. The changes ensure consistency in the terminology used throughout the project.

Terminology update:

* [`api/src/modules/calculations/cost.calculator.ts`](diffhunk://#diff-f3a786faa816de52227b70d447bbed13537c00886ffc27518b616149b4a2e4d7L237-R237): Updated the key name in the `CostCalculator` class.
* [`shared/dtos/custom-projects/custom-project-output.dto.ts`](diffhunk://#diff-eee98ecbdd9edf2e440d8945d6ed3a7e93e8b54f1a32b12aae251207ccd1dc6eL18-R18): Updated the type definition and sorted keys for `CustomProjectSummary`. [[1]](diffhunk://#diff-eee98ecbdd9edf2e440d8945d6ed3a7e93e8b54f1a32b12aae251207ccd1dc6eL18-R18) [[2]](diffhunk://#diff-eee98ecbdd9edf2e440d8945d6ed3a7e93e8b54f1a32b12aae251207ccd1dc6eL39-R39)

Test fixtures update:

* [`api/test/integration/calculations/fixtures/conservation-indonesia-mangrove.ts`](diffhunk://#diff-d9400b75fe7d4989a1f3fef7a71c9597bba8c80b48b0efb79ad68a5a8da0e684L108-R108): Updated the key name in the `CONSERVATION_INDONESIA_MANGROVE_OUTPUT` constant. [[1]](diffhunk://#diff-d9400b75fe7d4989a1f3fef7a71c9597bba8c80b48b0efb79ad68a5a8da0e684L108-R108) [[2]](diffhunk://#diff-d9400b75fe7d4989a1f3fef7a71c9597bba8c80b48b0efb79ad68a5a8da0e684L949-R949)
* [`api/test/integration/calculations/fixtures/restoration-china-salt-marsh.ts`](diffhunk://#diff-009ff202f454bc3b874822f5fc185fd68c197fd0672a631bdc00933e771b593bL48-R48): Updated the key name in the `RESTORATION_CHINA_SALT_MARSH` constant. [[1]](diffhunk://#diff-009ff202f454bc3b874822f5fc185fd68c197fd0672a631bdc00933e771b593bL48-R48) [[2]](diffhunk://#diff-009ff202f454bc3b874822f5fc185fd68c197fd0672a631bdc00933e771b593bL885-R885)
* [`api/test/integration/calculations/fixtures/restoration-mexico-mangroves.ts`](diffhunk://#diff-bf34828d331c3fb5e2a83755af3706b59854a353caeaccbe4ebe6dd25ee26594L162-R162): Updated the key name in the `RESTORATION_MEXICO_MANGROVES_OUTPUT` constant. [[1]](diffhunk://#diff-bf34828d331c3fb5e2a83755af3706b59854a353caeaccbe4ebe6dd25ee26594L162-R162) [[2]](diffhunk://#diff-bf34828d331c3fb5e2a83755af3706b59854a353caeaccbe4ebe6dd25ee26594L997-R997)