### PR TITLE
Feat/edit custom project

### DIFF
--- a/client/src/containers/my-projects/columns.tsx
+++ b/client/src/containers/my-projects/columns.tsx
@@ -11,6 +11,7 @@ import { ACTIVITY } from "@shared/entities/activity.enum";
 import { CustomProject as CustomProjectEntity } from "@shared/entities/custom-project.entity";
 import { useQueryClient } from "@tanstack/react-query";
 import { Table as TableInstance, Row, ColumnDef } from "@tanstack/react-table";
+import { PencilLineIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
 
 import { FEATURE_FLAGS } from "@/lib/feature-flags";
@@ -119,6 +120,14 @@ const ActionsDropdown = ({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-50" align="end">
+          {FEATURE_FLAGS["edit-project"] && !isHeader && (
+            <DropdownMenuItem asChild>
+              <Link href={`/projects/${instance.original.id}/edit`}>
+                <PencilLineIcon className="mr-1 h-4 w-4" />
+                Edit project
+              </Link>
+            </DropdownMenuItem>
+          )}
           {updateSelection && (
             <DropdownMenuItem>
               <ExclamationTriangleIcon className="mr-1 h-4 w-4" />

--- a/client/src/containers/projects/custom-project/details/index.tsx
+++ b/client/src/containers/projects/custom-project/details/index.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react";
 
 import Link from "next/link";
-import { useParams } from "next/navigation";
 
 import {
   ACTIVITY,
@@ -9,11 +8,13 @@ import {
 } from "@shared/entities/activity.enum";
 import { CARBON_REVENUES_TO_COVER } from "@shared/entities/custom-project.entity";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
+import { useAtomValue } from "jotai";
 import { FileEdit } from "lucide-react";
 
 import { FEATURE_FLAGS } from "@/lib/feature-flags";
 
 import DetailItem from "@/containers/projects/custom-project/details/detail-item";
+import { customProjectIdAtom } from "@/containers/projects/custom-project/store";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -55,7 +56,7 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({ data }) => {
     restorationActivity,
     sequestrationRate,
   } = data;
-  const { id } = useParams<{ id?: string }>();
+  const id = useAtomValue(customProjectIdAtom);
   const showEditButton = FEATURE_FLAGS["edit-project"] && id;
   return (
     <Card className="flex-1 space-y-1">

--- a/client/src/containers/projects/custom-project/header/index.tsx
+++ b/client/src/containers/projects/custom-project/header/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from "react";
+import { FC, useCallback } from "react";
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -18,6 +18,7 @@ import { projectsUIState } from "@/app/projects/store";
 
 import AuthDialog from "@/containers/auth/dialog";
 import CustomProjectParameters from "@/containers/projects/custom-project/header/parameters";
+import { customProjectIdAtom } from "@/containers/projects/custom-project/store";
 import Topbar from "@/containers/topbar";
 
 import { Button } from "@/components/ui/button";
@@ -32,7 +33,7 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
   const queryClient = useQueryClient();
   const { data: session } = useSession();
   const { toast } = useToast();
-  const [saved, setSaved] = useState<boolean>(false);
+  const [projectId, setProjectId] = useAtom(customProjectIdAtom);
   const pathname = usePathname();
 
   const SaveProject = useCallback(
@@ -49,9 +50,10 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
         if (status === 201) {
           // update the url without redirecting
           // TODO: should also implement a clean way of removing the query cache
-          window.history.replaceState(null, "", `/projects/${body.data.id}`);
+          const id = body.data.id;
+          window.history.replaceState(null, "", `/projects/${id}`);
           toast({ description: "Project updated successfully." });
-          setSaved(true);
+          setProjectId(id);
           await queryClient.invalidateQueries({
             queryKey: DEFAULT_CUSTOM_PROJECTS_QUERY_KEY,
           });
@@ -70,7 +72,7 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
         });
       }
     },
-    [session, data, toast, queryClient],
+    [session, data, toast, queryClient, setProjectId],
   );
   const handleOnSignIn = useCallback(async () => {
     // session is undefined when onSignIn callback is called
@@ -92,7 +94,7 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
     );
   }
 
-  if (saved || !pathname.includes("/projects/preview")) {
+  if (projectId || !pathname.includes("/projects/preview")) {
     ButtonComponent = (
       <Button asChild>
         <Link href="/my-projects">My custom projects</Link>

--- a/client/src/containers/projects/custom-project/index.tsx
+++ b/client/src/containers/projects/custom-project/index.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { FC } from "react";
+import { FC, useEffect } from "react";
 
 import { CustomProject as CustomProjectEntity } from "@shared/entities/custom-project.entity";
 import { motion } from "framer-motion";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 
 import { toPercentageValue } from "@/lib/format";
 
@@ -20,6 +20,7 @@ import CostDetails from "@/containers/projects/custom-project/cost-details";
 import ProjectDetails from "@/containers/projects/custom-project/details";
 import CustomProjectHeader from "@/containers/projects/custom-project/header";
 import LeftOver from "@/containers/projects/custom-project/left-over";
+import { customProjectIdAtom } from "@/containers/projects/custom-project/store";
 import ProjectSummary from "@/containers/projects/custom-project/summary";
 
 import { useSidebar } from "@/components/ui/sidebar";
@@ -58,6 +59,11 @@ const CustomProjectView: FC<{
   const redirectPath = id
     ? `/projects/${id}/edit`
     : "/projects/new?useCache=true";
+  const setProjectId = useSetAtom(customProjectIdAtom);
+
+  useEffect(() => {
+    return () => setProjectId(null);
+  }, [setProjectId]);
 
   return (
     <motion.div

--- a/client/src/containers/projects/custom-project/store.ts
+++ b/client/src/containers/projects/custom-project/store.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const customProjectIdAtom = atom<string | null>(null);

--- a/client/src/containers/projects/custom-project/summary/index.tsx
+++ b/client/src/containers/projects/custom-project/summary/index.tsx
@@ -1,10 +1,9 @@
 import { FC, useCallback, useEffect } from "react";
 
 import Link from "next/link";
-import { useParams } from "next/navigation";
 
 import { type CustomProjectSummary } from "@shared/dtos/custom-projects/custom-project-output.dto";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { FileEdit, XIcon } from "lucide-react";
 
 import { FEATURE_FLAGS } from "@/lib/feature-flags";
@@ -14,6 +13,7 @@ import { projectsUIState } from "@/app/projects/store";
 import { PROJECT_SUMMARY } from "@/constants/tooltip";
 
 import { SUMMARY_SIDEBAR_WIDTH } from "@/containers/projects/custom-project";
+import { customProjectIdAtom } from "@/containers/projects/custom-project/store";
 
 import { Button } from "@/components/ui/button";
 import InfoButton from "@/components/ui/info-button";
@@ -44,7 +44,7 @@ interface ProjectSummaryProps {
 }
 const ProjectSummary: FC<ProjectSummaryProps> = ({ data }) => {
   const setProjectSummaryOpen = useSetAtom(projectsUIState);
-  const { id } = useParams<{ id?: string }>();
+  const id = useAtomValue(customProjectIdAtom);
   const showEditButton = FEATURE_FLAGS["edit-project"] && id;
   const closeProjectSummary = useCallback(() => {
     setProjectSummaryOpen((prev) => ({

--- a/client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx
+++ b/client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx
@@ -81,6 +81,7 @@ export default function LossRate() {
       name="parameters.projectSpecificLossRate"
       render={() => (
         <NumberFormItem
+          id="parameters.projectSpecificLossRate"
           label="Project Specific Loss Rate"
           tooltip={{
             title: "Project Specific Loss Rate",

--- a/client/src/lib/feature-flags.ts
+++ b/client/src/lib/feature-flags.ts
@@ -44,7 +44,7 @@ interface FeatureFlags {
 
 const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   "intro-modal": true,
-  "edit-project": false,
+  "edit-project": true,
   "share-information": false,
   "project-comparison": false,
   "update-selection": false,

--- a/e2e/tests/custom-projects/create-custom-project.spec.ts
+++ b/e2e/tests/custom-projects/create-custom-project.spec.ts
@@ -45,6 +45,7 @@ test.describe("Custom Projects", () => {
 
     test("I can create a custom project with default values", async () => {
       await insertProjectName();
+      await page.locator("#parameters\\.projectSpecificLossRate").fill("-1");
       await submitCustomProjectAndCheckPreview();
     });
   });


### PR DESCRIPTION
## Edit Project Enabled

This PR enables the project editing feature by:

- Activating the "edit-project" feature flag
- Adding an "Edit project" option to the project actions dropdown
- Using Jotai to track the current project ID
- Refactoring components to use this centralized state instead of route parameters
- Adding cleanup logic to reset the project ID when navigating away
