### PR TITLE
fix(api): Remove implementation labor from overridable cost inputs fo…

### DIFF
--- a/api/src/modules/calculations/data.repository.ts
+++ b/api/src/modules/calculations/data.repository.ts
@@ -204,6 +204,9 @@ export class DataRepository extends Repository<BaseDataView> {
         `Could not find default Cost Inputs for country ${countryCode}, activity ${activity} and ecosystem ${ecosystem}`,
       );
     }
+    if (activity === ACTIVITY.CONSERVATION) {
+      costInputs.implementationLabor = undefined;
+    }
     return costInputs;
   }
 

--- a/api/test/integration/custom-projects/custom-projects-setup.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-setup.spec.ts
@@ -91,7 +91,6 @@ describe('Create Custom Projects - Setup', () => {
       establishingCarbonRights: 46666.6666666667,
       financingCost: 0.05,
       validation: 50000,
-      implementationLabor: 0,
       monitoring: 8400,
       maintenance: 0.0833,
       carbonStandardFees: 0.2,


### PR DESCRIPTION
This pull request includes a small change to the `DataRepository` class in the `data.repository.ts` file. The change adds a condition to handle the `CONSERVATION` activity by setting `implementationLabor` to `undefined`.

* [`api/src/modules/calculations/data.repository.ts`](diffhunk://#diff-c610941a76971fae93d7d206fcbe042270836b452cabbd2d24eb844e96cfdc2eR207-R209): Added a condition to set `implementationLabor` to `undefined` if the activity is `CONSERVATION`.