### PR TITLE
feat(api): Compute project costs at import time

### DIFF
--- a/api/src/modules/import/import.module.ts
+++ b/api/src/modules/import/import.module.ts
@@ -5,16 +5,19 @@ import { ImportController } from '@api/modules/import/import.controller';
 import { XlsxParser } from '@api/modules/import/services/xlsx.parser';
 import { EntityPreprocessor } from '@api/modules/import/services/entity.preprocessor';
 import { ExcelParserToken } from '@api/modules/import/services/excel-parser.interface';
-import { ImportRepository } from '@api/modules/import/import.repostiory';
+import { ImportRepository } from '@api/modules/import/import.repository';
 import { ImportEventHandler } from '@api/modules/import/events/handlers/import-event.handler';
 import { DataIngestionExcelParser } from '@api/modules/import/parser/data-ingestion.xlsx-parser';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProjectScorecard } from '@shared/entities/project-scorecard.entity';
+import { CalculationsModule } from '@api/modules/calculations/calculations.module';
+import { CustomProjectFactory } from '@api/modules/custom-projects/input-factory/custom-project.factory';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ProjectScorecard]),
     MulterModule.register({}),
+    CalculationsModule,
   ],
   controllers: [ImportController],
   providers: [
@@ -22,6 +25,7 @@ import { ProjectScorecard } from '@shared/entities/project-scorecard.entity';
     EntityPreprocessor,
     ImportRepository,
     ImportEventHandler,
+    CustomProjectFactory,
     DataIngestionExcelParser,
     { provide: ExcelParserToken, useClass: XlsxParser },
   ],

--- a/api/src/modules/import/import.service.ts
+++ b/api/src/modules/import/import.service.ts
@@ -4,7 +4,7 @@ import {
   ExcelParserInterface,
   ExcelParserToken,
 } from '@api/modules/import/services/excel-parser.interface';
-import { ImportRepository } from '@api/modules/import/import.repostiory';
+import { ImportRepository } from '@api/modules/import/import.repository';
 import { EventBus } from '@nestjs/cqrs';
 import { API_EVENT_TYPES } from '@api/modules/api-events/events.enum';
 import { ImportEvent } from '@api/modules/import/events/import.event';

--- a/api/src/modules/import/services/parsed-db-entities.type.ts
+++ b/api/src/modules/import/services/parsed-db-entities.type.ts
@@ -36,7 +36,7 @@ export type RecordSource = {
 export type RecordWithSources<T> = T & {
   sources?: RecordSource[];
 };
-type ParsedEntity<T> = {
+export type ParsedEntity<T> = {
   entity: EntityClass<T>;
   records: RecordWithSources<T>[];
 };


### PR DESCRIPTION
This pull request includes several changes to the import module, primarily focusing on fixing a typo in file names, adding new dependencies, and enhancing the `ImportRepository` class. The most important changes include renaming the `import.repostiory.ts` file, adding new modules and services, and implementing a new method to apply cost calculations to projects.

### File Renaming:
* Renamed `api/src/modules/import/import.repostiory.ts` to `api/src/modules/import/import.repository.ts` to fix a typo. [[1]](diffhunk://#diff-44eee6a78f8c508e10197de7455ce7eb024112d8cf35ed3fb66c69c792909ad6L8-R28) [[2]](diffhunk://#diff-8049c9e68444d48a6adbbd4d6558846ffeb008b5b3c8383db6e2797919efeed1L8-R16) [[3]](diffhunk://#diff-695dbebee9d4a7e0e05fd8c18fa8c56c5526003239ff604eb4b8931839c329b8L7-R7)

### Dependency Additions:
* Added `CalculationsModule` and `CustomProjectFactory` to the `ImportModule` imports and providers respectively.

### Enhancements to `ImportRepository`:
* Updated constructor to include `dataRepository`, `customProjectFactory`, and `calculationEngine` dependencies.
* Implemented `applyCostCalculationsToProjects` method to perform cost calculations on imported projects.
* Modified the `ingest` method to handle projects separately and apply cost calculations after other entities are saved.
* Added constants for default assumptions and conservation/restoration parameters.

### Type Changes:
* Exported `ParsedEntity` type in `parsed-db-entities.type.ts` to be used in other modules.