### PR TITLE
fix(backoffice): Fix entities pagination by adding sort options

### DIFF
--- a/backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts
+++ b/backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts
@@ -24,6 +24,10 @@ export const EcosystemExtentResource: ResourceWithOptions = {
       name: 'Data Management',
       icon: 'Database',
     },
+    sort: {
+      sortBy: 'countryCode',
+      direction: 'asc',
+    },
     listProperties: FIELD_ORDER,
     showProperties: FIELD_ORDER,
     editProperties: FIELD_ORDER,

--- a/backoffice/resources/sequestration-rate/sequestration-rate.resource.ts
+++ b/backoffice/resources/sequestration-rate/sequestration-rate.resource.ts
@@ -24,6 +24,10 @@ export const SequestrationRateResource: ResourceWithOptions = {
       name: 'Data Management',
       icon: 'Database',
     },
+    sort: {
+      sortBy: 'countryCode',
+      direction: 'asc',
+    },
     listProperties: FIELD_ORDER,
     editProperties: FIELD_ORDER,
     showProperties: FIELD_ORDER,

--- a/backoffice/resources/users/user.resource.ts
+++ b/backoffice/resources/users/user.resource.ts
@@ -1,14 +1,18 @@
-import { ResourceWithOptions } from "adminjs";
-import { User } from "@shared/entities/users/user.entity.js";
-import { createUserAction } from "./user.actions.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { User } from '@shared/entities/users/user.entity.js';
+import { createUserAction } from './user.actions.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const UserResource: ResourceWithOptions = {
   resource: User,
   options: {
     navigation: {
-      name: "User Management",
-      icon: "User",
+      name: 'User Management',
+      icon: 'User',
+    },
+    sort: {
+      sortBy: 'name',
+      direction: 'asc',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
@@ -20,7 +24,7 @@ export const UserResource: ResourceWithOptions = {
     },
     actions: {
       new: {
-        actionType: "resource",
+        actionType: 'resource',
         handler: createUserAction,
       },
     },


### PR DESCRIPTION
This pull request includes changes to the sorting functionality of resources in the `backoffice/resources` directory. The changes introduce sorting by specific fields in ascending order for better data management.

Sorting functionality added:

* [`backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts`](diffhunk://#diff-0b45eff5cee8d526f81ce7a485a3c5e4193e1ad8beddb386b0a79f1b13454196R27-R30): Added sorting by `countryCode` in ascending order.
* [`backoffice/resources/sequestration-rate/sequestration-rate.resource.ts`](diffhunk://#diff-c28b4e675843e9c96ff298a498bebe721a5c6bc05094a91745df10a50686556eR27-R30): Added sorting by `countryCode` in ascending order.
* [`backoffice/resources/users/user.resource.ts`](diffhunk://#diff-79ea066c4e4aed74baf773ba5925302df9104da5304a1b09444d625650491789L1-R15): Added sorting by `name` in ascending order. [[1]](diffhunk://#diff-79ea066c4e4aed74baf773ba5925302df9104da5304a1b09444d625650491789L1-R15) [[2]](diffhunk://#diff-79ea066c4e4aed74baf773ba5925302df9104da5304a1b09444d625650491789L23-R27)

Additionally, consistent usage of single quotes for string literals has been enforced in the `user.resource.ts` file.