### PR TITLE
fix(back office): Remove emission factors columns cause it is not in the model anymore

### DIFF
--- a/backoffice/resources/emission-factors/emission-factors.resource.ts
+++ b/backoffice/resources/emission-factors/emission-factors.resource.ts
@@ -42,9 +42,6 @@ export const EmissionFactorsResource: ResourceWithOptions = {
       ecosystem: {
         position: 2,
       },
-      emissionFactor: {
-        position: 4,
-      },
       AGB: {
         position: 5,
       },


### PR DESCRIPTION
This pull request includes a small change to the `backoffice/resources/emission-factors/emission-factors.resource.ts` file. The change removes the `emissionFactor` property from the `EmissionFactorsResource` object.

* [`backoffice/resources/emission-factors/emission-factors.resource.ts`](diffhunk://#diff-fba7695dfaaed317a8d3492550e260f86269082f04262cb8e1eabbdca837c3ddL45-L47): Removed the `emissionFactor` property from the `EmissionFactorsResource` object.