### PR TITLE
fix(client): Remove implementation labor from cost details for conservation projects

### DIFF
--- a/client/src/containers/projects/custom-project/cost-details/table/utils.ts
+++ b/client/src/containers/projects/custom-project/cost-details/table/utils.ts
@@ -1,11 +1,10 @@
 import { CustomProjectCostDetails } from "@shared/dtos/custom-projects/custom-project-output.dto";
-
 import { parseTableData } from "@/lib/utils";
-
 import { CostItem } from "@/containers/projects/custom-project/cost-details/table";
+import { ACTIVITY } from "@shared/entities/activity.enum";
 
-const customProjectCostDetailsLabelMap: Record<
-  keyof CustomProjectCostDetails,
+const CONSERVATION_PROJECT_COST_LABELS: Record<
+  Exclude<keyof CustomProjectCostDetails, "implementationLabor">,
   string
 > = {
   capitalExpenditure: "Capital expenditure",
@@ -16,7 +15,6 @@ const customProjectCostDetailsLabelMap: Record<
   blueCarbonProjectPlanning: "Blue carbon project planning",
   establishingCarbonRights: "Establishing carbon rights",
   validation: "Validation",
-  implementationLabor: "Implementation labor",
   operationalExpenditure: "Operating expenditure",
   monitoring: "Monitoring",
   maintenance: "Maintenance",
@@ -28,10 +26,25 @@ const customProjectCostDetailsLabelMap: Record<
   totalCost: "Total cost",
 } as const;
 
-function parseCostDetailsForTable(data?: CustomProjectCostDetails): CostItem[] {
+const RESTORATION_PROJECT_COST_LABELS: Record<
+  keyof CustomProjectCostDetails,
+  string
+> = {
+  ...CONSERVATION_PROJECT_COST_LABELS,
+  implementationLabor: "Implementation labor",
+} as const;
+
+function parseCostDetailsForTable(
+  activity: ACTIVITY,
+  data?: CustomProjectCostDetails,
+): CostItem[] {
   if (!data) return [];
 
-  return parseTableData(data, customProjectCostDetailsLabelMap);
+  if (activity === ACTIVITY.CONSERVATION) {
+    return parseTableData(data, CONSERVATION_PROJECT_COST_LABELS);
+  }
+
+  return parseTableData(data, RESTORATION_PROJECT_COST_LABELS);
 }
 
 export { parseCostDetailsForTable };

--- a/client/src/containers/projects/custom-project/index.tsx
+++ b/client/src/containers/projects/custom-project/index.tsx
@@ -54,6 +54,7 @@ const CustomProjectView: FC<{
     annualProjectCashFlowProps,
     summaryData,
   } = useCustomProjectOutput(data);
+
   const hasOpenBreakEvenPrice =
     data.output?.breakevenPriceComputationOutput !== null;
   const redirectPath = id

--- a/client/src/hooks/use-custom-project-output.ts
+++ b/client/src/hooks/use-custom-project-output.ts
@@ -73,14 +73,20 @@ export const useCustomProjectOutput = (
     };
   }, [data, output, priceType]);
 
-  const costDetailsProps = useMemo(
-    () =>
-      ({
-        total: parseCostDetailsForTable(output?.costDetails.total),
-        npv: parseCostDetailsForTable(output?.costDetails.npv),
-      })[costRangeSelector],
-    [costRangeSelector, output?.costDetails.total, output?.costDetails.npv],
-  );
+  const costDetailsProps = useMemo(() => {
+    const costDetails = {
+      total: parseCostDetailsForTable(
+        projectDetailsProps.data.activity,
+        output?.costDetails.total,
+      ),
+      npv: parseCostDetailsForTable(
+        projectDetailsProps.data.activity,
+        output?.costDetails.npv,
+      ),
+    };
+    const result = costDetails[costRangeSelector];
+    return result;
+  }, [costRangeSelector, output?.costDetails.total, output?.costDetails.npv]);
 
   const chartData = useMemo(
     () =>

--- a/shared/dtos/custom-projects/custom-project-output.dto.ts
+++ b/shared/dtos/custom-projects/custom-project-output.dto.ts
@@ -69,7 +69,7 @@ export type CustomProjectCostDetails = {
   blueCarbonProjectPlanning: number;
   establishingCarbonRights: number;
   validation: number;
-  implementationLabor: number;
+  implementationLabor?: number;
   monitoring: number;
   maintenance: number;
   communityBenefitSharingFund: number;


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of custom project cost details in the project management system. The most important changes include the introduction of separate label maps for conservation and restoration projects, updating the `parseCostDetailsForTable` function to handle different project activities, and modifying the `useCustomProjectOutput` hook to pass the activity type when parsing cost details.

### Improvements to cost details handling:

* [`client/src/containers/projects/custom-project/cost-details/table/utils.ts`](diffhunk://#diff-b7531b4a5e9fe352796c5ca575121807b801f16daad98dfab74d901e1cf71b5fR6-R31): Introduced `CONSERVATION_PROJECT_COST_LABELS` and `RESTORATION_PROJECT_COST_LABELS` to handle different labels for conservation and restoration projects.
* [`client/src/containers/projects/custom-project/cost-details/table/utils.ts`](diffhunk://#diff-b7531b4a5e9fe352796c5ca575121807b801f16daad98dfab74d901e1cf71b5fL31-R66): Updated `parseCostDetailsForTable` to accept an `ACTIVITY` parameter and use the appropriate label map based on the activity type.
* [`shared/dtos/custom-projects/custom-project-output.dto.ts`](diffhunk://#diff-eee98ecbdd9edf2e440d8945d6ed3a7e93e8b54f1a32b12aae251207ccd1dc6eL72-R72): Made `implementationLabor` an optional property in the `CustomProjectCostDetails` type to accommodate different project types.

### Updates to hooks and components:

* [`client/src/hooks/use-custom-project-output.ts`](diffhunk://#diff-f4164edac9e59b332f842d6c60825a2d64812f6fdf01802576b3827926aa877eL76-R89): Modified the `useCustomProjectOutput` hook to pass the activity type when calling `parseCostDetailsForTable`, ensuring the correct label map is used.

### Minor changes:

* [`client/src/containers/projects/custom-project/index.tsx`](diffhunk://#diff-dd7e419270850a219e5c894607e553a24b61f6319626b977141a154c6367c197R56): Added a minor formatting change.