### PR TITLE
fix(api): Solve the NaN issue during the excel import

### DIFF
--- a/api/src/modules/import/parser/data-ingestion.xlsx-parser.ts
+++ b/api/src/modules/import/parser/data-ingestion.xlsx-parser.ts
@@ -34,11 +34,21 @@ export class DataIngestionExcelParser implements IExcelParser {
         }
       }
 
-      const parsedTab = utils.sheet_to_json(tabContents, {
-        header: tabHeaders,
-        range: 1,
-        raw: true,
-      });
+      const parsedTab = utils
+        .sheet_to_json(tabContents, {
+          header: tabHeaders,
+          range: 1,
+          raw: true,
+        })
+        .map((row) => {
+          Object.keys(row).forEach((key) => {
+            // Fix for the NaN values produced by the excel with "NoData" values
+            if (row[key] === 'NoData') {
+              row[key] = undefined;
+            }
+          });
+          return row;
+        });
 
       parsedData[tabName] = parsedTab;
     }


### PR DESCRIPTION
This pull request includes a significant change to the `DataIngestionExcelParser` class in the `data-ingestion.xlsx-parser.ts` file. The change improves the handling of rows with 'NoData' values by converting them to `undefined` during the parsing process.

Improvements to data parsing:

* [`api/src/modules/import/parser/data-ingestion.xlsx-parser.ts`](diffhunk://#diff-7261aa4561bd64546afb142afbd91dc3c312e82695fb75b226b83bc8e537004fL37-R49): Modified the `parsedTab` construction to map over each row and replace 'NoData' values with `undefined`.