### PR TITLE
feat(backoffice): Related sources should be clickable and open their detail view when clicked

### DIFF
--- a/backoffice/components/molecules/many-2-many-sources.tsx
+++ b/backoffice/components/molecules/many-2-many-sources.tsx
@@ -1,6 +1,13 @@
 import React, { CSSProperties, useEffect, useState } from 'react';
 import { ApiClient, BasePropertyProps, RecordJSON, useNotice } from 'adminjs';
-import { Badge, Label, Icon, Button, Select } from '@adminjs/design-system';
+import {
+  Badge,
+  Label,
+  Icon,
+  Button,
+  Select,
+  Link,
+} from '@adminjs/design-system';
 import { ModelComponentSource } from '@shared/entities/methodology/model-component-source.entity.js';
 import { styled } from 'styled-components';
 import { SelectorOption } from '../atoms/selector.type.js';
@@ -239,7 +246,14 @@ const Many2ManySources: React.FC<Many2ManySourcesProps> = ({
             }}
           >
             <Badge>
-              {item.sourceType} - {item.source.name}
+              <Link
+                href={`/admin/resources/ModelComponentSource/records/${item.source.id}/show`}
+                style={{
+                  color: 'inherit',
+                }}
+              >
+                {item.sourceType} - {item.source.name}
+              </Link>
               {isEditView === true && (
                 <span
                   style={{


### PR DESCRIPTION
This pull request includes changes to the `backoffice/components/molecules/many-2-many-sources.tsx` file, primarily focused on enhancing the user interface and improving the code structure. The most important changes include adding a new `Link` component and updating the import statements for better readability.

User Interface Enhancements:

* Added a `Link` component to wrap the `Badge` displaying the source type and name, allowing users to navigate to the detailed view of the source.

Code Structure Improvements:

* Updated import statements to include `Link` from `@adminjs/design-system` and organized the imports for better readability.