### PR TITLE
fix(api): Remove stack trace from the response body

### DIFF
--- a/api/src/modules/import/import.service.ts
+++ b/api/src/modules/import/import.service.ts
@@ -73,7 +73,7 @@ export class ImportService {
       this.registerImportEvent(userId, this.eventMap.FAILED, {
         error: { type: e.constructor.name, message: e.message },
       });
-      throw new ConflictException(e);
+      throw new ConflictException('The excel file could not be imported');
     }
   }
 


### PR DESCRIPTION
This pull request includes a change to improve the error message in the `ImportService` class. The change modifies the exception message for a failed import to provide a clearer and more specific error description.

* [`api/src/modules/import/import.service.ts`](diffhunk://#diff-695dbebee9d4a7e0e05fd8c18fa8c56c5526003239ff604eb4b8931839c329b8L76-R76): Changed the `ConflictException` message to 'The excel file could not be imported' to provide a more user-friendly error message.