### PR TITLE
fix(client): use router from next/navigation and simplify project ID …

### DIFF
--- a/client/src/containers/projects/custom-project/details/index.tsx
+++ b/client/src/containers/projects/custom-project/details/index.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 
 import Link from "next/link";
+import { useParams } from "next/navigation";
 
 import {
   ACTIVITY,
@@ -20,7 +21,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
 export interface ProjectDetailsProps {
-  id?: string;
   data: {
     country: { code: string; name: string };
     projectSize: number;
@@ -43,7 +43,7 @@ export interface ProjectDetailsProps {
   };
 }
 
-const ProjectDetails: FC<ProjectDetailsProps> = ({ id, data }) => {
+const ProjectDetails: FC<ProjectDetailsProps> = ({ data }) => {
   const {
     country,
     projectSize,
@@ -58,6 +58,7 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({ id, data }) => {
     sequestrationRate,
   } = data;
   const idAtom = useAtomValue(customProjectIdAtom);
+  const { id } = useParams();
   const projectId = id || idAtom;
   const showEditButton = FEATURE_FLAGS["edit-project"] && projectId;
   return (

--- a/client/src/containers/projects/custom-project/header/index.tsx
+++ b/client/src/containers/projects/custom-project/header/index.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback } from "react";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { CustomProject as CustomProjectEntity } from "@shared/entities/custom-project.entity";
 import { useQueryClient } from "@tanstack/react-query";
@@ -35,6 +35,7 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
   const { toast } = useToast();
   const [projectId, setProjectId] = useAtom(customProjectIdAtom);
   const pathname = usePathname();
+  const router = useRouter();
 
   const SaveProject = useCallback(
     async (arg: Session | null = session) => {
@@ -48,10 +49,9 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
           });
 
         if (status === 201) {
-          // update the url without redirecting
           // TODO: should also implement a clean way of removing the query cache
           const id = body.data.id;
-          window.history.replaceState(null, "", `/projects/${id}`);
+          router.replace(`/projects/${id}`);
           toast({ description: "Project updated successfully." });
           setProjectId(id);
           await queryClient.invalidateQueries({
@@ -72,7 +72,7 @@ const CustomProjectHeader: FC<CustomProjectHeaderProps> = ({ data }) => {
         });
       }
     },
-    [session, data, toast, queryClient, setProjectId],
+    [session, data, toast, queryClient, setProjectId, router],
   );
   const handleOnSignIn = useCallback(async () => {
     // session is undefined when onSignIn callback is called

--- a/client/src/containers/projects/custom-project/index.tsx
+++ b/client/src/containers/projects/custom-project/index.tsx
@@ -112,7 +112,7 @@ const CustomProjectView: FC<{
         />
         <CustomProjectHeader data={data} />
         <div className="mb-4 mt-2 flex gap-4">
-          <ProjectDetails id={id} {...projectDetailsProps} />
+          <ProjectDetails {...projectDetailsProps} />
           {projectCostProps && <ProjectCost {...projectCostProps} />}
           {leftOverProps && <LeftOver {...leftOverProps} />}
           {costDetailsProps && (


### PR DESCRIPTION
## Navigation and Project ID Handling Improvements

### Changes
- Replaces direct window.history manipulation with Next.js's built-in router.replace
- Removes redundant `id` prop from ProjectDetails component

### Jira
- [TBCCT-367](https://vizzuality.atlassian.net/browse/TBCCT-367) 

[TBCCT-367]: https://vizzuality.atlassian.net/browse/TBCCT-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ