### PR TITLE
Fix/set implementation labor to 0 for conservation projects

### DIFF
--- a/api/src/modules/custom-projects/custom-projects.controller.ts
+++ b/api/src/modules/custom-projects/custom-projects.controller.ts
@@ -16,6 +16,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { RolesGuard } from '@api/modules/auth/guards/roles.guard';
 import { RequiredRoles } from '@api/modules/auth/decorators/roles.decorator';
 import { ROLES } from '@shared/entities/users/roles.enum';
+import { handleImplementationLabor } from '@api/modules/custom-projects/handle-implementation-labor';
 
 @Controller()
 export class CustomProjectsController {
@@ -76,7 +77,8 @@ export class CustomProjectsController {
     return tsRestHandler(
       customProjectContract.createCustomProject,
       async ({ body }) => {
-        const customProject = await this.customProjects.create(body);
+        const dto = handleImplementationLabor(body);
+        const customProject = await this.customProjects.create(dto);
         return {
           status: 201,
           body: { data: customProject },
@@ -84,7 +86,6 @@ export class CustomProjectsController {
       },
     );
   }
-
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
   @TsRestHandler(customProjectContract.saveCustomProject)
@@ -153,8 +154,8 @@ export class CustomProjectsController {
         ) {
           throw new ForbiddenException();
         }
-        const recalculatedCustomProject =
-          await this.customProjects.create(body);
+        const dto = handleImplementationLabor(body);
+        const recalculatedCustomProject = await this.customProjects.create(dto);
         const updatedEntity = await this.customProjects.update(id, {
           id,
           ...recalculatedCustomProject,

--- a/api/src/modules/custom-projects/handle-implementation-labor.ts
+++ b/api/src/modules/custom-projects/handle-implementation-labor.ts
@@ -1,0 +1,14 @@
+import { CreateCustomProjectDto } from '@shared/dtos/custom-projects/create-custom-project.dto';
+import { ACTIVITY } from '@shared/entities/activity.enum';
+
+/**
+ * @description: Temporal workaround to set implementation labor to 0 when project type is Conservation. This is a temporal solution for a tracked bug
+ *               when implementation labor is taken into account for Conservation projects.
+ */
+
+export const handleImplementationLabor = (dto: CreateCustomProjectDto) => {
+  if (dto.activity === ACTIVITY.CONSERVATION) {
+    dto.costInputs.implementationLabor = 0;
+  }
+  return dto;
+};

--- a/api/test/integration/custom-projects/implementation-labor.spec.ts
+++ b/api/test/integration/custom-projects/implementation-labor.spec.ts
@@ -1,0 +1,307 @@
+import { TestManager } from '../../utils/test-manager';
+import { customProjectContract } from '@shared/contracts/custom-projects.contract';
+import { CustomProjectsService } from '@api/modules/custom-projects/custom-projects.service';
+import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
+import { ACTIVITY } from '@shared/entities/activity.enum';
+import {
+  CARBON_REVENUES_TO_COVER,
+  CustomProject,
+  PROJECT_SPECIFIC_EMISSION,
+} from '@shared/entities/custom-project.entity';
+import { LOSS_RATE_USED } from '@shared/schemas/custom-projects/create-custom-project.schema';
+import { EMISSION_FACTORS_TIER_TYPES } from '@shared/entities/carbon-inputs/emission-factors.entity';
+import { User } from '@shared/entities/users/user.entity';
+
+/**
+ * @todo: This is a temporal workaround to set the implementation labor to 0 for conservation projects. Ideally we should fix this
+ *        by not using implementation labor for conservation projects, both in the model and handling it properly in the frontend.
+ *        Due to time constraints, we have decided to set it to 0 for now no matter if its a brand new project or a update.
+ *        This way it does not build up to other costs. This leaves a edge case bug that is tracked
+ */
+
+describe('Implementation Labor - Set to 0 for Conservation type of Projects', () => {
+  let testManager: TestManager;
+  let customProjectsService: CustomProjectsService;
+  let customProjectServiceSpy: jest.SpyInstance;
+  let token: string;
+  let user: User;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager();
+    await testManager.ingestCountries();
+    customProjectsService =
+      testManager.moduleFixture.get<CustomProjectsService>(
+        CustomProjectsService,
+      );
+    customProjectServiceSpy = jest
+      .spyOn(customProjectsService, 'create')
+      .mockResolvedValue({} as any);
+    const { jwtToken, user: testUser } = await testManager.setUpTestUser();
+    token = jwtToken;
+    user = testUser;
+  });
+
+  beforeEach(() => {
+    // This is required for the mock instance to not accumulate calls during the run so that each test has a clean slate for the spy
+    customProjectServiceSpy.mockClear();
+  });
+
+  afterAll(async () => {
+    jest.clearAllMocks();
+    await testManager.clearDatabase();
+    await testManager.close();
+  });
+
+  describe('Create Custom Project', () => {
+    test('should not override implementation labor if project type is restoration', async () => {
+      const sampleDto = {
+        countryCode: 'MEX',
+        projectName: 'Restoration Mexico Mangrove',
+        ecosystem: 'Mangrove',
+        activity: 'Restoration',
+        projectSizeHa: 500,
+        carbonRevenuesToCover: 'Capex and Opex',
+        initialCarbonPriceAssumption: 30,
+        assumptions: {
+          verificationFrequency: 5,
+          baselineReassessmentFrequency: 10,
+          discountRate: 0.04,
+          restorationRate: 250,
+          carbonPriceIncrease: 0.015,
+          buffer: 0.2,
+          projectLength: 20,
+        },
+        costInputs: {
+          feasibilityAnalysis: 50000,
+          conservationPlanningAndAdmin: 166766.666666667,
+          dataCollectionAndFieldCost: 26666.6666666667,
+          communityRepresentation: 72600,
+          blueCarbonProjectPlanning: 100000,
+          establishingCarbonRights: 46666.6666666667,
+          validation: 50000,
+          implementationLabor: 15986,
+          monitoring: 11900,
+          maintenance: 0.0833,
+          communityBenefitSharingFund: 0.5,
+          carbonStandardFees: 0.2,
+          baselineReassessment: 40000,
+          mrv: 75000,
+          longTermProjectOperatingCost: 31300,
+          financingCost: 0.05,
+        },
+        parameters: {
+          restorationActivity: 'Planting',
+          tierSelector: 'Tier 2 - Country-specific rate',
+          plantingSuccessRate: 0.008,
+        },
+      };
+
+      await testManager
+        .request()
+        .post(customProjectContract.createCustomProject.path)
+        .send(sampleDto);
+
+      expect(customProjectServiceSpy).toHaveBeenCalled();
+
+      const dtoReceived = customProjectServiceSpy.mock.calls[0][0];
+
+      expect(dtoReceived).toHaveProperty(
+        'costInputs.implementationLabor',
+        sampleDto.costInputs.implementationLabor,
+      );
+    });
+
+    test('should set implementation labor to 0 if project type is conservation', async () => {
+      const sampleDto = {
+        countryCode: 'IDN',
+        projectName: 'Conservation_Mangrove_Indonesia',
+        ecosystem: ECOSYSTEM.MANGROVE,
+        activity: ACTIVITY.CONSERVATION,
+        projectSizeHa: 10000,
+        carbonRevenuesToCover: CARBON_REVENUES_TO_COVER.OPEX,
+        initialCarbonPriceAssumption: 20,
+        assumptions: {
+          verificationFrequency: 5,
+          baselineReassessmentFrequency: 10,
+          discountRate: 0.04,
+          carbonPriceIncrease: 0.015,
+          buffer: 0.2,
+          projectLength: 20,
+        },
+        costInputs: {
+          feasibilityAnalysis: 50000,
+          conservationPlanningAndAdmin: 166766.666666667,
+          dataCollectionAndFieldCost: 26666.6666666667,
+          communityRepresentation: 71183.3333333333,
+          blueCarbonProjectPlanning: 100000,
+          establishingCarbonRights: 46666.6666666667,
+          validation: 50000,
+          implementationLabor: 1234,
+          monitoring: 15000,
+          maintenance: 0.0833,
+          communityBenefitSharingFund: 0.5,
+          carbonStandardFees: 0.2,
+          baselineReassessment: 40000,
+          mrv: 75000,
+          longTermProjectOperatingCost: 26400,
+          financingCost: 0.05,
+        },
+        parameters: {
+          lossRateUsed: LOSS_RATE_USED.PROJECT_SPECIFIC,
+          emissionFactorUsed: EMISSION_FACTORS_TIER_TYPES.TIER_2,
+          projectSpecificEmission:
+            PROJECT_SPECIFIC_EMISSION.ONE_EMISSION_FACTOR,
+          projectSpecificLossRate: -0.001,
+          projectSpecificEmissionFactor: 15,
+          emissionFactorAGB: 200,
+          emissionFactorSOC: 15,
+        },
+      };
+      await testManager
+        .request()
+        .post(customProjectContract.createCustomProject.path)
+        .send(sampleDto);
+
+      expect(customProjectServiceSpy).toHaveBeenCalled();
+
+      const dtoReceived = customProjectServiceSpy.mock.calls[0][0];
+
+      expect(dtoReceived).toHaveProperty('costInputs.implementationLabor', 0);
+    });
+  });
+  describe('Update Custom Project', () => {
+    let customProject: CustomProject;
+    beforeAll(async () => {
+      customProject = await testManager.mocks().createCustomProject({ user });
+    });
+
+    test('should not override implementation labor if project type is restoration', async () => {
+      const sampleDto = {
+        countryCode: 'MEX',
+        projectName: 'Restoration Mexico Mangrove',
+        ecosystem: 'Mangrove',
+        activity: 'Restoration',
+        projectSizeHa: 500,
+        carbonRevenuesToCover: 'Capex and Opex',
+        initialCarbonPriceAssumption: 30,
+        assumptions: {
+          verificationFrequency: 5,
+          baselineReassessmentFrequency: 10,
+          discountRate: 0.04,
+          restorationRate: 250,
+          carbonPriceIncrease: 0.015,
+          buffer: 0.2,
+          projectLength: 20,
+        },
+        costInputs: {
+          feasibilityAnalysis: 50000,
+          conservationPlanningAndAdmin: 166766.666666667,
+          dataCollectionAndFieldCost: 26666.6666666667,
+          communityRepresentation: 72600,
+          blueCarbonProjectPlanning: 100000,
+          establishingCarbonRights: 46666.6666666667,
+          validation: 50000,
+          implementationLabor: 15986,
+          monitoring: 11900,
+          maintenance: 0.0833,
+          communityBenefitSharingFund: 0.5,
+          carbonStandardFees: 0.2,
+          baselineReassessment: 40000,
+          mrv: 75000,
+          longTermProjectOperatingCost: 31300,
+          financingCost: 0.05,
+        },
+        parameters: {
+          restorationActivity: 'Planting',
+          tierSelector: 'Tier 2 - Country-specific rate',
+          plantingSuccessRate: 0.008,
+        },
+      };
+
+      await testManager
+        .request()
+        .patch(
+          customProjectContract.updateCustomProject.path.replace(
+            ':id',
+            customProject.id,
+          ),
+        )
+        .send(sampleDto)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(customProjectServiceSpy).toHaveBeenCalled();
+
+      const dtoReceived = customProjectServiceSpy.mock.calls[0][0];
+
+      expect(dtoReceived).toHaveProperty(
+        'costInputs.implementationLabor',
+        sampleDto.costInputs.implementationLabor,
+      );
+    });
+    test('should set implementation labor to 0 if project type is conservation', async () => {
+      const customProject = await testManager
+        .mocks()
+        .createCustomProject({ user });
+      const sampleDto = {
+        countryCode: 'IDN',
+        projectName: 'Conservation_Mangrove_Indonesia',
+        ecosystem: ECOSYSTEM.MANGROVE,
+        activity: ACTIVITY.CONSERVATION,
+        projectSizeHa: 10000,
+        carbonRevenuesToCover: CARBON_REVENUES_TO_COVER.OPEX,
+        initialCarbonPriceAssumption: 20,
+        assumptions: {
+          verificationFrequency: 5,
+          baselineReassessmentFrequency: 10,
+          discountRate: 0.04,
+          carbonPriceIncrease: 0.015,
+          buffer: 0.2,
+          projectLength: 20,
+        },
+        costInputs: {
+          feasibilityAnalysis: 50000,
+          conservationPlanningAndAdmin: 166766.666666667,
+          dataCollectionAndFieldCost: 26666.6666666667,
+          communityRepresentation: 71183.3333333333,
+          blueCarbonProjectPlanning: 100000,
+          establishingCarbonRights: 46666.6666666667,
+          validation: 50000,
+          implementationLabor: 1234,
+          monitoring: 15000,
+          maintenance: 0.0833,
+          communityBenefitSharingFund: 0.5,
+          carbonStandardFees: 0.2,
+          baselineReassessment: 40000,
+          mrv: 75000,
+          longTermProjectOperatingCost: 26400,
+          financingCost: 0.05,
+        },
+        parameters: {
+          lossRateUsed: LOSS_RATE_USED.PROJECT_SPECIFIC,
+          emissionFactorUsed: EMISSION_FACTORS_TIER_TYPES.TIER_2,
+          projectSpecificEmission:
+            PROJECT_SPECIFIC_EMISSION.ONE_EMISSION_FACTOR,
+          projectSpecificLossRate: -0.001,
+          projectSpecificEmissionFactor: 15,
+          emissionFactorAGB: 200,
+          emissionFactorSOC: 15,
+        },
+      };
+      await testManager
+        .request()
+        .patch(
+          customProjectContract.updateCustomProject.path.replace(
+            ':id',
+            customProject.id,
+          ),
+        )
+        .send(sampleDto)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(customProjectServiceSpy).toHaveBeenCalled();
+
+      const dtoReceived = customProjectServiceSpy.mock.calls[0][0];
+      expect(dtoReceived).toHaveProperty('costInputs.implementationLabor', 0);
+    });
+  });
+});

--- a/api/test/integration/projects/create-projects.spec.ts
+++ b/api/test/integration/projects/create-projects.spec.ts
@@ -4,8 +4,8 @@ import { ACTIVITY } from '@shared/entities/activity.enum';
 import { ECOSYSTEM } from '@shared/entities/ecosystem.enum';
 import { ProjectScorecard } from '@shared/entities/project-scorecard.entity';
 import { Project, PROJECT_PRICE_TYPE } from '@shared/entities/projects.entity';
-import { TestManager } from 'api/test/utils/test-manager';
-import { TestUser } from 'api/test/utils/user.auth';
+import { TestManager } from '../../utils/test-manager';
+import { TestUser } from '../../utils/user.auth';
 
 describe('Create projects', () => {
   let testManager: TestManager;

--- a/shared/contracts/custom-projects.contract.ts
+++ b/shared/contracts/custom-projects.contract.ts
@@ -76,7 +76,7 @@ export const customProjectContract = contract.router({
     method: "PATCH",
     path: "/custom-projects/:id",
     pathParams: z.object({
-      id: z.coerce.string(),
+      id: z.coerce.string().uuid(),
     }),
     responses: {
       200: contract.type<ApiResponse<CustomProject>>(),


### PR DESCRIPTION
Adds a handler to override implementation labor to 0 when creating or updating a custom project when project type is Conservation.

This is a workaround for a known bug when implementation labor is used even when project type is Conservation