### PR TITLE
fix: populate upsert back office country selector using the custom api endpoint

### DIFF
--- a/backoffice/components/atoms/country-selector.tsx
+++ b/backoffice/components/atoms/country-selector.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { BasePropertyProps } from 'adminjs';
+import { Label, Select } from '@adminjs/design-system';
+import { Config } from '../../../backoffice/components/config/Config.js';
+
+const CountrySelector: React.FC<BasePropertyProps> = ({
+  property,
+  record,
+  onChange,
+}) => {
+  const [options, setOptions] = useState<{ value: string; label: string }[]>(
+    [],
+  );
+
+  useEffect(() => {
+    fetch(Config.ADMINJS_CONFIG_ENDPOINT).then(async (res) => {
+      const config = await res.json();
+
+      const countriesRes = await fetch(
+        `${config.apiUrl}/custom-projects/available-countries`,
+      );
+
+      const countries = await countriesRes.json();
+      setOptions(
+        countries.data.map((country: { code: string; name: string }) => ({
+          value: country.code,
+          label: country.name,
+        })),
+      );
+    });
+  }, []);
+
+  return (
+    <div style={{ marginBottom: '16px' }}>
+      <Label
+        style={{
+          textTransform: 'capitalize',
+        }}
+      >
+        Country
+      </Label>
+      <Select
+        //@ts-expect-error
+        options={options}
+        value={options.find(
+          (option) => option.value === record!.params[property.path],
+        )}
+        onChange={(selected) => onChange!(property.path, selected?.value)}
+        isClearable
+      />
+      <div style={{ height: '24px' }}></div>
+    </div>
+  );
+};
+
+export default CountrySelector;

--- a/backoffice/components/config/Config.ts
+++ b/backoffice/components/config/Config.ts
@@ -1,0 +1,3 @@
+export const Config = {
+  ADMINJS_CONFIG_ENDPOINT: '/admin/config',
+};

--- a/backoffice/components/index.tsx
+++ b/backoffice/components/index.tsx
@@ -12,4 +12,8 @@ export const Components = {
     'Many2ManySources',
     './molecules/many-2-many-sources',
   ),
+  CountrySelector: componentLoader.add(
+    'CountrySelector',
+    './atoms/country-selector.tsx',
+  ),
 };

--- a/backoffice/index.ts
+++ b/backoffice/index.ts
@@ -45,6 +45,7 @@ import { componentLoader, Components } from 'backoffice/components/index.js';
 import { ModelComponentSourceResource } from 'backoffice/resources/model-component-source/model-component-source.resource.js';
 import { EcosystemExtentResource } from 'backoffice/resources/ecosystem-extent/ecosystem-extent.resource.js';
 import path from 'path';
+import { Config } from 'backoffice/components/config/Config.js';
 
 AdminJS.registerAdapter({
   Database: AdminJSTypeorm.Database,
@@ -235,6 +236,19 @@ const start = async () => {
       },
     },
   );
+
+  // Config ENDPOINT
+  adminRouter.get('/config', async (req, res) => {
+    const user = (
+      req.session as undefined | (session.Session & { adminUser: any })
+    )?.adminUser as any;
+
+    if (!user || user.role !== 'admin') {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    res.json({ apiUrl: process.env.API_URL });
+  });
 
   app.use(`${ROOT_PATH}/public`, express.static(path.join('.', 'public')));
   app.use(admin.options.rootPath, adminRouter);

--- a/backoffice/resources/projects/projects.resource.ts
+++ b/backoffice/resources/projects/projects.resource.ts
@@ -3,6 +3,7 @@ import { Project } from '@shared/entities/projects.entity.js';
 import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 import { projectsContract } from '@shared/contracts/projects.contract.js';
 import { ProjectActions } from 'backoffice/resources/projects/project.actions.js';
+import { Components } from 'backoffice/components/index.js';
 
 const CREATE_EDIT_FORM_FIELDS = [
   'projectName',
@@ -20,6 +21,11 @@ export const ProjectsResource: ResourceWithOptions = {
   options: {
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
+      countryCode: {
+        components: {
+          edit: Components.CountrySelector,
+        },
+      },
       initialPriceAssumption: {
         description: 'Initial carbon price assumption',
       },


### PR DESCRIPTION
This pull request introduces a new `CountrySelector` component for the backoffice application. The changes include the creation of the component, configuration updates, and integration into the existing project resources. The most important changes are as follows:

### New Component Addition:

* [`backoffice/components/atoms/country-selector.tsx`](diffhunk://#diff-2e974719d37b42d49d536d39cc5455b077e265e196237a24c30770139d6df0dcR1-R56): Added a new `CountrySelector` component that fetches available countries from an API and displays them in a dropdown menu.

### Configuration Updates:

* [`backoffice/components/config/Config.ts`](diffhunk://#diff-08a2d10595d90264db4c2af267802e915eb205a871432d5206e33768d46af08aR1-R3): Introduced a new configuration file to store the `ADMINJS_CONFIG_ENDPOINT` constant.

### Integration into Existing System:

* [`backoffice/components/index.tsx`](diffhunk://#diff-6578adf0cd0f93e792d3f60cc2726b34dc3175a853e34f2eb381418a1287e4b6R15-R18): Registered the new `CountrySelector` component with the component loader.
* [`backoffice/index.ts`](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R48): Imported the `Config` file and added a new endpoint to serve the configuration for the admin panel. [[1]](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R48) [[2]](diffhunk://#diff-748e5cd1c2a59cf8dfcd0e9645994a676a6662143cc6dc23fa52213c32a37405R240-R252)
* [`backoffice/resources/projects/projects.resource.ts`](diffhunk://#diff-030fdc808735407f7b223c723488f354d0121c3819392fe9f29fa7cb69aadea2R6): Integrated the `CountrySelector` component into the project resource for editing the `countryCode` field. [[1]](diffhunk://#diff-030fdc808735407f7b223c723488f354d0121c3819392fe9f29fa7cb69aadea2R6) [[2]](diffhunk://#diff-030fdc808735407f7b223c723488f354d0121c3819392fe9f29fa7cb69aadea2R24-R28)