### PR TITLE
[TBCCT-379/291]uses v2 map endpoint to retrieve abatement per country

### DIFF
--- a/client/src/containers/overview/map/layers/projects/index.tsx
+++ b/client/src/containers/overview/map/layers/projects/index.tsx
@@ -17,7 +17,7 @@ export default function ProjectsLayer() {
 
   const queryKey = geometriesKeys.all(filters).queryKey;
 
-  const { data, isSuccess } = client.projects.getProjectsMap.useQuery(
+  const { data, isSuccess } = client.projects.getProjectsMapV2.useQuery(
     queryKey,
     {
       query: {

--- a/client/src/containers/overview/map/popup/index.tsx
+++ b/client/src/containers/overview/map/popup/index.tsx
@@ -24,7 +24,7 @@ export default function CostAbatementPopup() {
       <table className="mt-2">
         <thead>
           <tr>
-            <th className={cn(HEADER_CLASSES, "pr-2")}>Cost (total, USD)</th>
+            <th className={cn(HEADER_CLASSES, "pr-2")}>AVG Cost (USD)</th>
             <th className={cn(HEADER_CLASSES, "px-2")}>Abatement (tCO2e)</th>
           </tr>
         </thead>
@@ -42,7 +42,7 @@ export default function CostAbatementPopup() {
         </tbody>
       </table>
       <p className="mt-2 text-xs text-muted-foreground">
-        Values for the SUM of all project combinations.
+        Values for the country
       </p>
     </MapPopup>
   );


### PR DESCRIPTION
This pull request includes updates to the `ProjectsLayer` and `CostAbatementPopup` components in the `client/src/containers/overview/map` directory. The changes involve modifying queries and updating table headers and descriptions.

Changes to queries and data fetching:

* [`client/src/containers/overview/map/layers/projects/index.tsx`](diffhunk://#diff-75746c8395816d4de3c48010210c66d0b2eef6fb3dfde641c6aa205440262370L20-R20): Updated the query method from `getProjectsMap` to `getProjectsMapV2` to fetch project data.

Changes to UI text:

* [`client/src/containers/overview/map/popup/index.tsx`](diffhunk://#diff-611d5db67170296f3da4bd0b5f368d847e0ac4e153f5bde17daf4e4f3c58c810L27-R27): Updated the table header from "Cost (total, USD)" to "AVG Cost (USD)" for clarity.
* [`client/src/containers/overview/map/popup/index.tsx`](diffhunk://#diff-611d5db67170296f3da4bd0b5f368d847e0ac4e153f5bde17daf4e4f3c58c810L45-R45): Changed the description text from "Values for the SUM of all project combinations." to "Values for the country" to provide more accurate information.