### PR TITLE
feat: changed default value of plantingSuccessRate and enable form input

### DIFF
--- a/client/src/containers/projects/form/number-form-item.tsx
+++ b/client/src/containers/projects/form/number-form-item.tsx
@@ -61,7 +61,10 @@ export default function NumberFormItem({
 
   useEffect(() => {
     if (value) {
-      setState(value.toString());
+      const newValue = isPercentage
+        ? toPercentageValue(Number(value))
+        : value.toString();
+      setState(newValue);
     }
   }, [value]);
 

--- a/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
+++ b/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
@@ -193,9 +193,10 @@ export default function RestorationProjectDetails() {
                 formControlClassName="after:content-['%']"
                 min={0}
                 value={form.getValues("parameters.plantingSuccessRate")}
+                onValueChange={async (v) =>
+                  handleFormChange("parameters.plantingSuccessRate", v)
+                }
                 isPercentage
-                readOnly
-                disabled
               />
             )}
           />

--- a/e2e/tests/custom-projects/edit-custom-project.spec.ts
+++ b/e2e/tests/custom-projects/edit-custom-project.spec.ts
@@ -124,7 +124,9 @@ test.describe("Custom Projects - Edit", () => {
     expect(
       page.locator("input[name='parameters.plantingSuccessRate']"),
     ).toHaveValue(
-      DEFAULT_RESTORATION_FORM_VALUES.parameters.plantingSuccessRate.toString(),
+      (
+        DEFAULT_RESTORATION_FORM_VALUES.parameters.plantingSuccessRate * 100
+      ).toString(),
     );
   });
 });

--- a/shared/schemas/custom-projects/custom-project-form.constants.ts
+++ b/shared/schemas/custom-projects/custom-project-form.constants.ts
@@ -73,7 +73,7 @@ export const DEFAULT_RESTORATION_FORM_VALUES: Pick<
   parameters: {
     restorationActivity: RESTORATION_ACTIVITY_SUBTYPE.PLANTING,
     tierSelector: SEQUESTRATION_RATE_TIER_TYPES.TIER_1,
-    plantingSuccessRate: 0.8,
+    plantingSuccessRate: 0.6,
     projectSpecificSequestrationRate: 15,
     restorationYearlyBreakdown: [],
   },


### PR DESCRIPTION
## Update Planting Success Rate Handling and Default Value

### Changes
- Modified `NumberFormItem` component to properly handle percentage values
- Updated `plantingSuccessRate` default value from 0.8 to 0.6
- Made planting success rate field editable in restoration project details
- Fixed percentage display in form inputs
- Updated e2e test to reflect new percentage-based value handling

### Jira
- [TBCCT-387](https://vizzuality.atlassian.net/browse/TBCCT-387)

[TBCCT-387]: https://vizzuality.atlassian.net/browse/TBCCT-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ