### PR TITLE
fix(back-office): Sort and group sidebar elements in the back office sidebar

### DIFF
--- a/backoffice/index.ts
+++ b/backoffice/index.ts
@@ -43,6 +43,7 @@ import { EcosystemExtentResource } from 'backoffice/resources/ecosystem-extent/e
 import path from 'path';
 import { Config } from 'backoffice/components/config/Config.js';
 import { UserUploadResource } from 'backoffice/resources/users/user-upload.resource.js';
+import { User } from '@shared/entities/users/user.entity.js';
 
 AdminJS.registerAdapter({
   Database: AdminJSTypeorm.Database,
@@ -94,37 +95,44 @@ const start = async () => {
     rootPath: ROOT_PATH,
     componentLoader,
     resources: [
-      UserResource,
+      // User management
       UserUploadResource,
-      ProjectSizeResource,
-      FeasibilityAnalysisResource,
-      ConservationAndPlanningAdminResource,
-      CommunityRepresentationResource,
-      CarbonRightsResource,
-      FinancingCostResource,
-      ValidationCostResource,
-      MonitoringCostResource,
-      MaintenanceResource,
-      DataCollectionAndFieldCostResource,
-      CommunityBenefitResource,
-      CarbonStandardFeesResource,
-      CommunityCashFlowResource,
-      EcosystemLossResource,
-      RestorableLandResource,
-      EmissionFactorsResource,
-      BaselineReassessmentResource,
-      MRVResource,
-      BlueCarbonProjectPlanningResource,
-      LongTermProjectOperatingResource,
-      SequestrationRateResource,
+      UserResource,
+
+      // Projects
       ProjectsResource,
-      ImplementationLaborCostResource,
-      BaseSizeResource,
+
+      // Model Components
       BaseIncreaseResource,
-      ModelAssumptionResource,
+      BaseSizeResource,
+      BaselineReassessmentResource,
+      BlueCarbonProjectPlanningResource,
+      CarbonRightsResource,
+      CarbonStandardFeesResource,
+      CommunityBenefitResource,
+      CommunityCashFlowResource,
+      CommunityRepresentationResource,
+      ConservationAndPlanningAdminResource,
       CountryResource,
-      ModelComponentSourceResource,
+      DataCollectionAndFieldCostResource,
       EcosystemExtentResource,
+      EcosystemLossResource,
+      EmissionFactorsResource,
+      FeasibilityAnalysisResource,
+      FinancingCostResource,
+      ImplementationLaborCostResource,
+      LongTermProjectOperatingResource,
+      MaintenanceResource,
+      ModelAssumptionResource,
+      MonitoringCostResource,
+      MRVResource,
+      ProjectSizeResource,
+      RestorableLandResource,
+      SequestrationRateResource,
+      ValidationCostResource,
+
+      // Methodology
+      ModelComponentSourceResource,
     ],
     pages: {
       'data-upload': {
@@ -152,7 +160,7 @@ const start = async () => {
             ProjectSize: 'Project Sizes',
             // Note: This is the title of the pages section in the sidebar.
             // see full example here: https://github.com/SoftwareBrothers/adminjs/blob/master/src/locale/en/translation.json
-            pages: 'Uploads',
+            // pages: 'Uploads',
           },
           resources: {
             ProjectSize: {

--- a/backoffice/resources/base-increase/base-increase.resource.ts
+++ b/backoffice/resources/base-increase/base-increase.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { BaseIncrease } from "@shared/entities/base-increase.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { BaseIncrease } from '@shared/entities/base-increase.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const BaseIncreaseResource: ResourceWithOptions = {
   resource: BaseIncrease,
   options: {
     sort: {
-      sortBy: "ecosystem",
-      direction: "desc",
+      sortBy: 'ecosystem',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/base-size/base-size.resource.ts
+++ b/backoffice/resources/base-size/base-size.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { BaseSize } from "@shared/entities/base-size.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { BaseSize } from '@shared/entities/base-size.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const BaseSizeResource: ResourceWithOptions = {
   resource: BaseSize,
   options: {
     sort: {
-      sortBy: "ecosystem",
-      direction: "desc",
+      sortBy: 'ecosystem',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/baseline-reassesment/baseline-reassesment.resource.ts
+++ b/backoffice/resources/baseline-reassesment/baseline-reassesment.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { BaselineReassessment } from "@shared/entities/cost-inputs/baseline-reassessment.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { BaselineReassessment } from '@shared/entities/cost-inputs/baseline-reassessment.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const BaselineReassessmentResource: ResourceWithOptions = {
   resource: BaselineReassessment,
   options: {
     sort: {
-      sortBy: "baselineReassessmentCost",
-      direction: "desc",
+      sortBy: 'baselineReassessmentCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/blue-carbon-project-planning/blue-carbon-project-planning.resource.ts
+++ b/backoffice/resources/blue-carbon-project-planning/blue-carbon-project-planning.resource.ts
@@ -19,8 +19,8 @@ export const BlueCarbonProjectPlanningResource: ResourceWithOptions = {
       direction: 'desc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
   },
 };

--- a/backoffice/resources/carbon-estandard-fees/carbon-estandard-fees.resource.ts
+++ b/backoffice/resources/carbon-estandard-fees/carbon-estandard-fees.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { CarbonStandardFees } from "@shared/entities/cost-inputs/carbon-standard-fees.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { CarbonStandardFees } from '@shared/entities/cost-inputs/carbon-standard-fees.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const CarbonStandardFeesResource: ResourceWithOptions = {
   resource: CarbonStandardFees,
   options: {
     sort: {
-      sortBy: "carbonStandardFee",
-      direction: "desc",
+      sortBy: 'carbonStandardFee',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/carbon-righs/carbon-rights.resource.ts
+++ b/backoffice/resources/carbon-righs/carbon-rights.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { CarbonRights } from "@shared/entities/cost-inputs/establishing-carbon-rights.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { CarbonRights } from '@shared/entities/cost-inputs/establishing-carbon-rights.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const CarbonRightsResource: ResourceWithOptions = {
   resource: CarbonRights,
   options: {
     sort: {
-      sortBy: "carbonRightsCost",
-      direction: "desc",
+      sortBy: 'carbonRightsCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/community-benefit/community-benefit.resource.ts
+++ b/backoffice/resources/community-benefit/community-benefit.resource.ts
@@ -1,17 +1,17 @@
-import { CommunityBenefitSharingFund } from "@shared/entities/cost-inputs/community-benefit-sharing-fund.entity.js";
-import { ResourceWithOptions } from "adminjs";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { CommunityBenefitSharingFund } from '@shared/entities/cost-inputs/community-benefit-sharing-fund.entity.js';
+import { ResourceWithOptions } from 'adminjs';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const CommunityBenefitResource: ResourceWithOptions = {
   resource: CommunityBenefitSharingFund,
   options: {
     sort: {
-      sortBy: "communityBenefitSharingFund",
-      direction: "desc",
+      sortBy: 'communityBenefitSharingFund',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/community-cash-flow/community-cash-flow.resource.ts
+++ b/backoffice/resources/community-cash-flow/community-cash-flow.resource.ts
@@ -1,17 +1,17 @@
-import { CommunityCashFlow } from "@shared/entities/cost-inputs/community-cash-flow.entity.js";
-import { ResourceWithOptions } from "adminjs";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { CommunityCashFlow } from '@shared/entities/cost-inputs/community-cash-flow.entity.js';
+import { ResourceWithOptions } from 'adminjs';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const CommunityCashFlowResource: ResourceWithOptions = {
   resource: CommunityCashFlow,
   options: {
     sort: {
-      sortBy: "cashflowType",
-      direction: "asc",
+      sortBy: 'cashflowType',
+      direction: 'asc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/community-representation/community-representation.resource.ts
+++ b/backoffice/resources/community-representation/community-representation.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { CommunityRepresentation } from "@shared/entities/cost-inputs/community-representation.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { CommunityRepresentation } from '@shared/entities/cost-inputs/community-representation.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const CommunityRepresentationResource: ResourceWithOptions = {
   resource: CommunityRepresentation,
   options: {
     sort: {
-      sortBy: "liaisonCost",
-      direction: "desc",
+      sortBy: 'liaisonCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/conservation-and-planning-admin/conservation-and-planning-admin.resource.ts
+++ b/backoffice/resources/conservation-and-planning-admin/conservation-and-planning-admin.resource.ts
@@ -1,6 +1,6 @@
-import { ResourceWithOptions } from "adminjs";
-import { ConservationPlanningAndAdmin } from "@shared/entities/cost-inputs/conservation-and-planning-admin.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { ConservationPlanningAndAdmin } from '@shared/entities/cost-inputs/conservation-and-planning-admin.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const ConservationAndPlanningAdminResource: ResourceWithOptions = {
   resource: ConservationPlanningAndAdmin,
@@ -12,12 +12,12 @@ export const ConservationAndPlanningAdminResource: ResourceWithOptions = {
       },
     },
     sort: {
-      sortBy: "planningCost",
-      direction: "desc",
+      sortBy: 'planningCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
   },
 };

--- a/backoffice/resources/countries/country.resource.ts
+++ b/backoffice/resources/countries/country.resource.ts
@@ -16,8 +16,8 @@ export const CountryResource: ResourceWithOptions = {
       direction: 'asc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
   },
 };

--- a/backoffice/resources/data-collection-and-field-cost/data-collection-and-field-cost.resource.ts
+++ b/backoffice/resources/data-collection-and-field-cost/data-collection-and-field-cost.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { DataCollectionAndFieldCosts } from "@shared/entities/cost-inputs/data-collection-and-field-costs.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { DataCollectionAndFieldCosts } from '@shared/entities/cost-inputs/data-collection-and-field-costs.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const DataCollectionAndFieldCostResource: ResourceWithOptions = {
   resource: DataCollectionAndFieldCosts,
   options: {
     sort: {
-      sortBy: "fieldCost",
-      direction: "desc",
+      sortBy: 'fieldCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts
+++ b/backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts
@@ -21,8 +21,8 @@ export const EcosystemExtentResource: ResourceWithOptions = {
   resource: EcosystemExtent,
   options: {
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     sort: {
       sortBy: 'countryCode',

--- a/backoffice/resources/ecosystem-loss/ecosystem-loss.resource.ts
+++ b/backoffice/resources/ecosystem-loss/ecosystem-loss.resource.ts
@@ -9,8 +9,8 @@ export const EcosystemLossResource: ResourceWithOptions = {
       direction: 'desc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/emission-factors/emission-factors.resource.ts
+++ b/backoffice/resources/emission-factors/emission-factors.resource.ts
@@ -31,8 +31,8 @@ export const EmissionFactorsResource: ResourceWithOptions = {
       direction: 'asc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/feasability-analysis/feasability-analysis.resource.ts
+++ b/backoffice/resources/feasability-analysis/feasability-analysis.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { FeasibilityAnalysis } from "@shared/entities/cost-inputs/feasability-analysis.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { FeasibilityAnalysis } from '@shared/entities/cost-inputs/feasability-analysis.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const FeasibilityAnalysisResource: ResourceWithOptions = {
   resource: FeasibilityAnalysis,
   options: {
     sort: {
-      sortBy: "analysisCost",
-      direction: "desc",
+      sortBy: 'analysisCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/financing-cost/financing-cost.resource.ts
+++ b/backoffice/resources/financing-cost/financing-cost.resource.ts
@@ -1,16 +1,16 @@
-import { ResourceWithOptions } from "adminjs";
-import { FinancingCost } from "@shared/entities/cost-inputs/financing-cost.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { FinancingCost } from '@shared/entities/cost-inputs/financing-cost.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 export const FinancingCostResource: ResourceWithOptions = {
   resource: FinancingCost,
   options: {
     sort: {
-      sortBy: "financingCostCapexPercent",
-      direction: "desc",
+      sortBy: 'financingCostCapexPercent',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/implementation-labor-cost/implementation-labor-cost.resource.ts
+++ b/backoffice/resources/implementation-labor-cost/implementation-labor-cost.resource.ts
@@ -26,8 +26,8 @@ export const ImplementationLaborCostResource: ResourceWithOptions = {
       direction: 'desc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     listProperties: FIELD_ORDER,
     showProperties: FIELD_ORDER,

--- a/backoffice/resources/long-term-project-operating/long-term-project-operating.resource.ts
+++ b/backoffice/resources/long-term-project-operating/long-term-project-operating.resource.ts
@@ -1,16 +1,16 @@
-import { ResourceWithOptions } from "adminjs";
-import { LongTermProjectOperating } from "@shared/entities/cost-inputs/long-term-project-operating.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { LongTermProjectOperating } from '@shared/entities/cost-inputs/long-term-project-operating.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 export const LongTermProjectOperatingResource: ResourceWithOptions = {
   resource: LongTermProjectOperating,
   options: {
     sort: {
-      sortBy: "longTermProjectOperatingCost",
-      direction: "desc",
+      sortBy: 'longTermProjectOperatingCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/maintenance/maintenance.resource.ts
+++ b/backoffice/resources/maintenance/maintenance.resource.ts
@@ -24,8 +24,8 @@ export const MaintenanceResource: ResourceWithOptions = {
       direction: 'desc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     listProperties: FIELD_ORDER,
     showProperties: FIELD_ORDER,

--- a/backoffice/resources/model-assumptions/model-assumptions.resource.ts
+++ b/backoffice/resources/model-assumptions/model-assumptions.resource.ts
@@ -10,8 +10,8 @@ export const ModelAssumptionResource: ResourceWithOptions = {
       direction: 'desc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/monitoring-cost/monitoring-cost.resource.ts
+++ b/backoffice/resources/monitoring-cost/monitoring-cost.resource.ts
@@ -1,17 +1,17 @@
-import { ResourceWithOptions } from "adminjs";
-import { MonitoringCost } from "@shared/entities/cost-inputs/monitoring.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { MonitoringCost } from '@shared/entities/cost-inputs/monitoring.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 
 export const MonitoringCostResource: ResourceWithOptions = {
   resource: MonitoringCost,
   options: {
     sort: {
-      sortBy: "monitoringCost",
-      direction: "desc",
+      sortBy: 'monitoringCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/mrv/mrv.resource.ts
+++ b/backoffice/resources/mrv/mrv.resource.ts
@@ -1,16 +1,16 @@
-import { ResourceWithOptions } from "adminjs";
-import { MRV } from "@shared/entities/cost-inputs/mrv.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { MRV } from '@shared/entities/cost-inputs/mrv.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 export const MRVResource: ResourceWithOptions = {
   resource: MRV,
   options: {
     sort: {
-      sortBy: "mrvCost",
-      direction: "desc",
+      sortBy: 'mrvCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/project-size/project-size.resource.ts
+++ b/backoffice/resources/project-size/project-size.resource.ts
@@ -9,8 +9,8 @@ export const ProjectSizeResource: ResourceWithOptions = {
       direction: 'desc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     listProperties: ['countryCode', 'ecosystem', 'activity', 'sizeHa'],
     showProperties: ['countryCode', 'ecosystem', 'activity', 'sizeHa'],

--- a/backoffice/resources/projects/projects.resource.ts
+++ b/backoffice/resources/projects/projects.resource.ts
@@ -54,8 +54,8 @@ export const ProjectsResource: ResourceWithOptions = {
       direction: 'asc',
     },
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Projects',
+      icon: 'Folder',
     },
     actions: {
       new: {

--- a/backoffice/resources/restorable-land/restorable-land.resource.ts
+++ b/backoffice/resources/restorable-land/restorable-land.resource.ts
@@ -1,16 +1,16 @@
-import { ResourceWithOptions } from "adminjs";
-import { RestorableLand } from "@shared/entities/carbon-inputs/restorable-land.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { RestorableLand } from '@shared/entities/carbon-inputs/restorable-land.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 export const RestorableLandResource: ResourceWithOptions = {
   resource: RestorableLand,
   options: {
     sort: {
-      sortBy: "restorableLand",
-      direction: "desc",
+      sortBy: 'restorableLand',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,

--- a/backoffice/resources/sequestration-rate/sequestration-rate.resource.ts
+++ b/backoffice/resources/sequestration-rate/sequestration-rate.resource.ts
@@ -21,8 +21,8 @@ export const SequestrationRateResource: ResourceWithOptions = {
   resource: SequestrationRate,
   options: {
     navigation: {
-      name: 'Data Management',
-      icon: 'Database',
+      name: 'Model Components',
+      icon: 'Settings',
     },
     sort: {
       sortBy: 'countryCode',

--- a/backoffice/resources/users/user-upload.resource.ts
+++ b/backoffice/resources/users/user-upload.resource.ts
@@ -9,9 +9,16 @@ const FIELD_NAMES = ['user', 'uploadedAt', 'files'];
 export const UserUploadResource: ResourceWithOptions = {
   resource: UserUpload,
   options: {
+    translations: {
+      en: {
+        labels: {
+          UserUpload: 'File submissions',
+        },
+      },
+    },
     navigation: {
-      name: 'Files',
-      icon: 'File',
+      name: 'User Management',
+      icon: 'User',
     },
     showProperties: FIELD_NAMES,
     editProperties: FIELD_NAMES,

--- a/backoffice/resources/users/user.resource.ts
+++ b/backoffice/resources/users/user.resource.ts
@@ -6,6 +6,13 @@ import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 export const UserResource: ResourceWithOptions = {
   resource: User,
   options: {
+    translations: {
+      en: {
+        labels: {
+          User: 'User Accounts',
+        },
+      },
+    },
     navigation: {
       name: 'User Management',
       icon: 'User',

--- a/backoffice/resources/validation-cost/validation-cost.resource.ts
+++ b/backoffice/resources/validation-cost/validation-cost.resource.ts
@@ -1,16 +1,16 @@
-import { ResourceWithOptions } from "adminjs";
-import { ValidationCost } from "@shared/entities/cost-inputs/validation.entity.js";
-import { GLOBAL_COMMON_PROPERTIES } from "../common/common.resources.js";
+import { ResourceWithOptions } from 'adminjs';
+import { ValidationCost } from '@shared/entities/cost-inputs/validation.entity.js';
+import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
 export const ValidationCostResource: ResourceWithOptions = {
   resource: ValidationCost,
   options: {
     sort: {
-      sortBy: "validationCost",
-      direction: "desc",
+      sortBy: 'validationCost',
+      direction: 'desc',
     },
     navigation: {
-      name: "Data Management",
-      icon: "Database",
+      name: 'Model Components',
+      icon: 'Settings',
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,


### PR DESCRIPTION
This pull request introduces significant restructuring and cleanup in the `backoffice` module, focusing on resource organization and navigation improvements. The changes include reordering resources for better logical grouping, updating navigation labels and icons for consistency, and standardizing code formatting for imports and properties.

### Resource Organization and Navigation Updates:
* Reordered resources in `backoffice/index.ts` to group them into logical categories: `User Management`, `Projects`, `Model Components`, and `Methodology`. This improves clarity and maintainability.
* Updated navigation labels and icons across multiple resources to replace "Data Management" with "Model Components" and the "Database" icon with "Settings" for consistency. Examples include `BaseIncreaseResource` [[1]](diffhunk://#diff-85f655079c6c9b44226845c994e207c15e3a64da57ae375f9584434fcb2b9537L1-R14) `CarbonRightsResource` [[2]](diffhunk://#diff-adf3519cb1881bbe66de7897fe8dc1226816297d3ce0b94bb2fc776877d6e648L1-R14) and others.

### Code Formatting and Cleanup:
* Standardized import statements across resource files to use single quotes instead of double quotes for consistency. Examples include `BaseIncreaseResource` [[1]](diffhunk://#diff-85f655079c6c9b44226845c994e207c15e3a64da57ae375f9584434fcb2b9537L1-R14) and `CommunityBenefitResource` [[2]](diffhunk://#diff-8503a07dfb2e8be8822a658e0cf24f5069e5a75bcfddc5a240af00fe7db865a8L1-R14).
* Commented out the "Uploads" page label in the sidebar configuration in `backoffice/index.ts` as it is no longer used.