### PR TITLE
fix: User ROLES.PARTNER to ROLES.USER and back office navigation tab names

### DIFF
--- a/api/src/modules/auth/authentication.controller.ts
+++ b/api/src/modules/auth/authentication.controller.ts
@@ -42,7 +42,7 @@ export class AuthenticationController {
     @Headers('origin') origin: string,
   ): Promise<ControllerResponse> {
     return tsRestHandler(authContract.register, async ({ body }) => {
-      const userToRegister = { ...body, role: ROLES.PARTNER };
+      const userToRegister = { ...body, role: ROLES.USER };
       await this.authService.addUser(origin, userToRegister);
       return {
         body: null,

--- a/api/src/modules/custom-projects/custom-projects.controller.ts
+++ b/api/src/modules/custom-projects/custom-projects.controller.ts
@@ -87,7 +87,7 @@ export class CustomProjectsController {
     );
   }
   @UseGuards(AuthGuard('jwt'), RolesGuard)
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   @TsRestHandler(customProjectContract.saveCustomProject)
   async snapshot(@GetUser() user: User): Promise<ControllerResponse> {
     return tsRestHandler(
@@ -103,7 +103,7 @@ export class CustomProjectsController {
   }
 
   @UseGuards(AuthGuard('jwt'), RolesGuard)
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   @TsRestHandler(customProjectContract.getCustomProject)
   async getCustomProjectById(
     @GetUser() user: User,
@@ -118,7 +118,7 @@ export class CustomProjectsController {
   }
 
   @UseGuards(AuthGuard('jwt'), RolesGuard)
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   @TsRestHandler(customProjectContract.getCustomProjects)
   async getCustomProjects(@GetUser() user: User): Promise<ControllerResponse> {
     return tsRestHandler(
@@ -141,7 +141,7 @@ export class CustomProjectsController {
   }
 
   @UseGuards(AuthGuard('jwt'), RolesGuard)
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   @TsRestHandler(customProjectContract.updateCustomProject)
   async updateCustomProject(
     @GetUser() user: User,
@@ -169,7 +169,7 @@ export class CustomProjectsController {
   }
 
   @UseGuards(AuthGuard('jwt'), RolesGuard)
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   @TsRestHandler(customProjectContract.deleteCustomProjects)
   async deleteCustomProjects(
     @GetUser() user: User,

--- a/api/src/modules/import/import.controller.ts
+++ b/api/src/modules/import/import.controller.ts
@@ -76,7 +76,7 @@ export class ImportController {
   }
 
   @UseInterceptors(AnyFilesInterceptor({ limits: { files: 3, fields: 0 } }))
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   @TsRestHandler(usersContract.uploadData)
   async uploadData(
     @GetUser() user: User,
@@ -110,7 +110,7 @@ export class ImportController {
   }
 
   @TsRestHandler(usersContract.listUploadDataTemplates)
-  @RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+  @RequiredRoles(ROLES.USER, ROLES.ADMIN)
   public async downloadUserUploadTemplates(): Promise<ControllerResponse> {
     return tsRestHandler(usersContract.listUploadDataTemplates, async () => {
       return {

--- a/api/src/modules/users/users.controller.ts
+++ b/api/src/modules/users/users.controller.ts
@@ -23,7 +23,7 @@ import { ROLES } from '@shared/entities/users/roles.enum';
 @Controller()
 @UseInterceptors(ClassSerializerInterceptor)
 @UseGuards(JwtAuthGuard, RolesGuard)
-@RequiredRoles(ROLES.PARTNER, ROLES.ADMIN)
+@RequiredRoles(ROLES.USER, ROLES.ADMIN)
 export class UsersController {
   constructor(
     private usersService: UsersService,

--- a/api/test/integration/auth/create-user.spec.ts
+++ b/api/test/integration/auth/create-user.spec.ts
@@ -37,7 +37,7 @@ describe('Create Users', () => {
     // But the user has the role partner
 
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'random@test.com',
     });
     const { jwtToken } = await testManager.logUserIn(user);
@@ -95,7 +95,7 @@ describe('Create Users', () => {
       .findOne({ where: { email: newUser.email } });
 
     expect(createdUser.isActive).toBe(false);
-    expect(createdUser.role).toBe(ROLES.PARTNER);
+    expect(createdUser.role).toBe(ROLES.USER);
     expect(mockEmailService.sendMail).toHaveBeenCalledTimes(1);
   });
 

--- a/api/test/integration/auth/delete-account.spec.ts
+++ b/api/test/integration/auth/delete-account.spec.ts
@@ -21,7 +21,7 @@ describe('Delete Account', () => {
   test("An existing user should be able to delete it's account", async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',

--- a/api/test/integration/auth/password-recovery-reset-password.spec.ts
+++ b/api/test/integration/auth/password-recovery-reset-password.spec.ts
@@ -31,7 +31,7 @@ describe('Password Recovery - Reset Password', () => {
   test('Successfully resetting the password with a valid token', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',
@@ -70,7 +70,7 @@ describe('Password Recovery - Reset Password', () => {
   test('Failing to reset the password with an expired token', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',

--- a/api/test/integration/auth/password-recovery-send-email.spec.ts
+++ b/api/test/integration/auth/password-recovery-send-email.spec.ts
@@ -25,7 +25,7 @@ describe('Password Recovery - Send Email', () => {
   test('An email should be sent if a user is found', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',

--- a/api/test/integration/auth/sign-in.spec.ts
+++ b/api/test/integration/auth/sign-in.spec.ts
@@ -36,7 +36,7 @@ describe('Sign In', () => {
   test('Should return 401 when user tries to sign in with an incorrect password', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'random@test.com',
     });
 
@@ -57,7 +57,7 @@ describe('Sign In', () => {
   test('Should return 201 and an access token when user successfully signs in', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',
@@ -108,7 +108,7 @@ describe('Sign In', () => {
   test('Should return UNAUTHORIZED when trying to sign in with an inactive account', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: false,
       password: '12345678',

--- a/api/test/integration/auth/sign-up.spec.ts
+++ b/api/test/integration/auth/sign-up.spec.ts
@@ -27,7 +27,7 @@ describe('Sign Up', () => {
     // Given a user exists with valid credentials
     // But the user has the role partner
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'random@test.com',
     });
 
@@ -46,7 +46,7 @@ describe('Sign Up', () => {
 
   test('Sign up should fail if the auto-generated password is incorrect', async () => {
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'random@test.com',
       isActive: false,
     });
@@ -67,7 +67,7 @@ describe('Sign Up', () => {
 
   test('Sign up should succeed if the auto-generated password is correct and the user should be activated and allowed to get a access token', async () => {
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: false,
       password: '1234567812345678',

--- a/api/test/integration/auth/validate-token.spec.ts
+++ b/api/test/integration/auth/validate-token.spec.ts
@@ -33,7 +33,7 @@ describe('Validate Token', () => {
   test('Validating a valid reset-password token', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',
@@ -100,7 +100,7 @@ describe('Validate Token', () => {
   test('Validating a reset-password token with an incorrect type parameter', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',
@@ -125,7 +125,7 @@ describe('Validate Token', () => {
   test('Validating a reset-password token without specifying the type', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',
@@ -150,7 +150,7 @@ describe('Validate Token', () => {
   test('Validating a valid access token', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',
@@ -213,7 +213,7 @@ describe('Validate Token', () => {
   test('Validating an access token with an incorrect type parameter', async () => {
     // Given a user exists with valid credentials
     const user = await testManager.mocks().createUser({
-      role: ROLES.PARTNER,
+      role: ROLES.USER,
       email: 'test@test.com',
       isActive: true,
       password: '12345678',

--- a/api/test/integration/import/import-scorecard.spec.ts
+++ b/api/test/integration/import/import-scorecard.spec.ts
@@ -47,7 +47,7 @@ describe('Import Tests', () => {
     it('should throw an error if the user is not an admin', async () => {
       const nonAdminUser = await testManager
         .mocks()
-        .createUser({ role: ROLES.PARTNER, email: 'testtt@user.com' });
+        .createUser({ role: ROLES.USER, email: 'testtt@user.com' });
 
       const { jwtToken } = await testManager.logUserIn(nonAdminUser);
 

--- a/api/test/integration/import/import.spec.ts
+++ b/api/test/integration/import/import.spec.ts
@@ -46,7 +46,7 @@ describe('Import Tests', () => {
     it('should throw an error if the user is not an admin', async () => {
       const nonAdminUser = await testManager
         .mocks()
-        .createUser({ role: ROLES.PARTNER, email: 'testtt@user.com' });
+        .createUser({ role: ROLES.USER, email: 'testtt@user.com' });
 
       const { jwtToken } = await testManager.logUserIn(nonAdminUser);
 

--- a/api/test/integration/users/users-email-update.spec.ts
+++ b/api/test/integration/users/users-email-update.spec.ts
@@ -35,10 +35,10 @@ describe('Users ME (e2e)', () => {
     it('Should fail if the new email is already in use, and no email should be sent', async () => {
       const previousUser = await testManager
         .mocks()
-        .createUser({ role: ROLES.PARTNER });
+        .createUser({ role: ROLES.USER });
       const user = await testManager
         .mocks()
-        .createUser({ email: 'user2@mail.com', role: ROLES.PARTNER });
+        .createUser({ email: 'user2@mail.com', role: ROLES.USER });
 
       const { jwtToken } = await testManager.logUserIn(user);
 
@@ -53,9 +53,7 @@ describe('Users ME (e2e)', () => {
     });
 
     it('Should send an email to the new email address', async () => {
-      const user = await testManager
-        .mocks()
-        .createUser({ role: ROLES.PARTNER });
+      const user = await testManager.mocks().createUser({ role: ROLES.USER });
       const { jwtToken } = await testManager.logUserIn(user);
 
       const newEmail = 'newmail@test.com';
@@ -73,7 +71,7 @@ describe('Users ME (e2e)', () => {
     it('should update the email and return the updated user', async () => {
       const user = await testManager
         .mocks()
-        .createUser({ email: 'test@test.com', role: ROLES.PARTNER });
+        .createUser({ email: 'test@test.com', role: ROLES.USER });
 
       const { emailUpdateToken } = await jwt.signEmailUpdateToken(user.id);
       const newEmail = 'new-mail@mail.com';
@@ -90,7 +88,7 @@ describe('Users ME (e2e)', () => {
     it('should fail if the new email is already in use', async () => {
       const user = await createUser(testManager.getDataSource(), {
         email: 'user@test.com',
-        role: ROLES.PARTNER,
+        role: ROLES.USER,
       });
 
       const { emailUpdateToken } = await jwt.signEmailUpdateToken(user.id);

--- a/api/test/integration/users/users-me.spec.ts
+++ b/api/test/integration/users/users-me.spec.ts
@@ -26,7 +26,7 @@ describe('Users ME (e2e)', () => {
         createdUsers.push(
           await testManager.mocks().createUser({
             email: `user${n}@mail.com`,
-            role: ROLES.PARTNER,
+            role: ROLES.USER,
           }),
         );
       }
@@ -45,7 +45,7 @@ describe('Users ME (e2e)', () => {
     it('should update my own password', async () => {
       const user = await testManager
         .mocks()
-        .createUser({ email: 'test@test.com', role: ROLES.PARTNER });
+        .createUser({ email: 'test@test.com', role: ROLES.USER });
 
       const { jwtToken, password: oldPassword } =
         await testManager.logUserIn(user);
@@ -75,7 +75,7 @@ describe('Users ME (e2e)', () => {
     it('should update a user name', async () => {
       const user = await testManager.mocks().createUser({
         email: 'user@test.com',
-        role: ROLES.PARTNER,
+        role: ROLES.USER,
       });
 
       const { jwtToken } = await testManager.logUserIn(user);
@@ -106,7 +106,7 @@ describe('Users ME (e2e)', () => {
         users.push(
           await testManager
             .mocks()
-            .createUser({ email: `user${n}@test.com`, role: ROLES.PARTNER }),
+            .createUser({ email: `user${n}@test.com`, role: ROLES.USER }),
         );
       }
       const user = users[0];

--- a/backoffice/index.ts
+++ b/backoffice/index.ts
@@ -156,7 +156,7 @@ const start = async () => {
           labels: {
             User: 'Users',
             Country: 'Countries',
-            Project: 'Projects',
+            Project: 'Project Scenarios',
             ProjectSize: 'Project Sizes',
             // Note: This is the title of the pages section in the sidebar.
             // see full example here: https://github.com/SoftwareBrothers/adminjs/blob/master/src/locale/en/translation.json

--- a/client/src/containers/profile/account-details/schema.ts
+++ b/client/src/containers/profile/account-details/schema.ts
@@ -4,6 +4,6 @@ import { z } from "zod";
 
 export const accountDetailsSchema = UpdateUserSchema.and(
   z.object({
-    role: z.enum([ROLES.ADMIN, ROLES.PARTNER]).optional(),
+    role: z.enum([ROLES.ADMIN, ROLES.USER]).optional(),
   }),
 );

--- a/shared/entities/users/roles.enum.ts
+++ b/shared/entities/users/roles.enum.ts
@@ -1,4 +1,4 @@
 export enum ROLES {
   ADMIN = "admin",
-  PARTNER = "partner",
+  USER = "user",
 }

--- a/shared/entities/users/user.entity.ts
+++ b/shared/entities/users/user.entity.ts
@@ -37,7 +37,7 @@ export class User extends BaseEntity {
 
   @Column({
     type: "enum",
-    default: ROLES.PARTNER,
+    default: ROLES.USER,
     enum: ROLES,
     enumName: "user_roles",
   })


### PR DESCRIPTION
This pull request updates role-based access control across the application, changing the default role for users from `ROLES.PARTNER` to `ROLES.USER`. The changes affect both the core application logic and the associated integration tests.

### Application Logic Updates:

* Updated the default role assigned during user registration in `AuthenticationController` to `ROLES.USER` (`api/src/modules/auth/authentication.controller.ts`).
* Adjusted required roles for various endpoints in `CustomProjectsController`, `ImportController`, and `UsersController` to replace `ROLES.PARTNER` with `ROLES.USER`. [[1]](diffhunk://#diff-cc9c8bff38622ff15dd4ba62ed57da7aa1af212d09902ea07100a2182a45147eL90-R90) [[2]](diffhunk://#diff-cc9c8bff38622ff15dd4ba62ed57da7aa1af212d09902ea07100a2182a45147eL106-R106) [[3]](diffhunk://#diff-cc9c8bff38622ff15dd4ba62ed57da7aa1af212d09902ea07100a2182a45147eL121-R121) [[4]](diffhunk://#diff-cc9c8bff38622ff15dd4ba62ed57da7aa1af212d09902ea07100a2182a45147eL144-R144) [[5]](diffhunk://#diff-cc9c8bff38622ff15dd4ba62ed57da7aa1af212d09902ea07100a2182a45147eL172-R172) [[6]](diffhunk://#diff-4ed2660ea42131107f248d52bde409186e43eb3b926b389ecba3f34cd67553fdL79-R79) [[7]](diffhunk://#diff-4ed2660ea42131107f248d52bde409186e43eb3b926b389ecba3f34cd67553fdL113-R113) [[8]](diffhunk://#diff-0d74284ac33d7d456d2e4b5953fb1ce7d0db340013e79f4ec3082485a94492b9L26-R26)

### Integration Test Updates:

* Updated user role in test cases across multiple test files to reflect the new default role (`ROLES.USER`), ensuring consistent behavior and validation:
  - `create-user.spec.ts`, `delete-account.spec.ts`, `password-recovery-reset-password.spec.ts`, and `password-recovery-send-email.spec.ts`. [[1]](diffhunk://#diff-df027b8f208a2d061d220bf2f116b4eb64de03e0951132205b5fe5068e0a077cL40-R40) [[2]](diffhunk://#diff-df027b8f208a2d061d220bf2f116b4eb64de03e0951132205b5fe5068e0a077cL98-R98) [[3]](diffhunk://#diff-0975b43b5ab7d2cea5f0220f51694ee7a05ac8a7bc8115eee414575d3429676bL24-R24) [[4]](diffhunk://#diff-4c61a3e67b7fdf0a61b083c397362d3c6e57bed314641284919b29c92e412955L34-R34) [[5]](diffhunk://#diff-4c61a3e67b7fdf0a61b083c397362d3c6e57bed314641284919b29c92e412955L73-R73) [[6]](diffhunk://#diff-9ffcd5be7ab6555b6e683d14235b5750bd50ece319c550a661d64fe303f77d2cL28-R28)
  - `sign-in.spec.ts` and `sign-up.spec.ts`. [[1]](diffhunk://#diff-4e15af35dc5b1568960824b6a52eac747d5620980731fe8e6354939bfffb924fL39-R39) [[2]](diffhunk://#diff-4e15af35dc5b1568960824b6a52eac747d5620980731fe8e6354939bfffb924fL60-R60) [[3]](diffhunk://#diff-4e15af35dc5b1568960824b6a52eac747d5620980731fe8e6354939bfffb924fL111-R111) [[4]](diffhunk://#diff-7f799a4f11e172ed35c2c8a5436165426162ab26407296a4223d2008022bae50L30-R30) [[5]](diffhunk://#diff-7f799a4f11e172ed35c2c8a5436165426162ab26407296a4223d2008022bae50L49-R49) [[6]](diffhunk://#diff-7f799a4f11e172ed35c2c8a5436165426162ab26407296a4223d2008022bae50L70-R70)
  - `validate-token.spec.ts`. [[1]](diffhunk://#diff-d409b5a30d2d99adfd939955337dc97cb3d827eccca819fb60d3e07a7edd0103L36-R36) [[2]](diffhunk://#diff-d409b5a30d2d99adfd939955337dc97cb3d827eccca819fb60d3e07a7edd0103L103-R103) [[3]](diffhunk://#diff-d409b5a30d2d99adfd939955337dc97cb3d827eccca819fb60d3e07a7edd0103L128-R128) [[4]](diffhunk://#diff-d409b5a30d2d99adfd939955337dc97cb3d827eccca819fb60d3e07a7edd0103L153-R153) [[5]](diffhunk://#diff-d409b5a30d2d99adfd939955337dc97cb3d827eccca819fb60d3e07a7edd0103L216-R216)
  - `import-scorecard.spec.ts` and `import.spec.ts`. [[1]](diffhunk://#diff-358c4e65abc8e5d2c95f3ec9eb19dd8d78e2489f0d0f4edf2f57ac6f18e524faL50-R50) [[2]](diffhunk://#diff-485d70d3f800b425f6e5ba50fbbd325f34837f4d8ae3b5a8290c5df6f46b236aL49-R49)
  - `users-email-update.spec.ts` and `users-me.spec.ts`. [[1]](diffhunk://#diff-f2123e7ea1d9c7caad52332d01ea27f27b7157c214ebe595f6bfeae2e9f3bf5bL38-R41) [[2]](diffhunk://#diff-f2123e7ea1d9c7caad52332d01ea27f27b7157c214ebe595f6bfeae2e9f3bf5bL56-R56) [[3]](diffhunk://#diff-f2123e7ea1d9c7caad52332d01ea27f27b7157c214ebe595f6bfeae2e9f3bf5bL76-R74) [[4]](diffhunk://#diff-f2123e7ea1d9c7caad52332d01ea27f27b7157c214ebe595f6bfeae2e9f3bf5bL93-R91) [[5]](diffhunk://#diff-9769434fc3f9c2a82b9f54ae9a46c21c70b54d8c8b0a15ade501a86b3cadf727L29-R29) [[6]](diffhunk://#diff-9769434fc3f9c2a82b9f54ae9a46c21c70b54d8c8b0a15ade501a86b3cadf727L48-R48)