### PR TITLE
TBCCT-406: Retrieve planting success rate as part of activity defaults

### DIFF
--- a/api/src/modules/calculations/data.repository.ts
+++ b/api/src/modules/calculations/data.repository.ts
@@ -226,18 +226,23 @@ export class DataRepository extends Repository<BaseDataView> {
   ): Promise<RestorationActivityDefaults> {
     const { countryCode, ecosystem } = dto;
 
-    const result = await this.findOne({
+    const baseCostAndCarbonInputs = await this.findOneOrFail({
       where: { countryCode, ecosystem, activity: ACTIVITY.RESTORATION },
-      select: ['activity', 'tier1SequestrationRate', 'tier2SequestrationRate'],
+      select: ['tier1SequestrationRate', 'tier2SequestrationRate'],
     });
-    if (result === null) return null;
+
+    const plantingSuccessRate = await this.assumptionsRepository.findOneOrFail({
+      where: { name: 'Planting success rate' },
+    });
+
+    if (baseCostAndCarbonInputs === null) return null;
 
     return {
-      activity: result.activity,
       sequestrationRate: {
-        tier1: result.tier1SequestrationRate,
-        tier2: result.tier2SequestrationRate,
+        tier1: baseCostAndCarbonInputs.tier1SequestrationRate,
+        tier2: baseCostAndCarbonInputs.tier2SequestrationRate,
       },
+      plantingSuccessRate: parseFloat(plantingSuccessRate.value),
     };
   }
 

--- a/api/test/integration/custom-projects/custom-projects-setup.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-setup.spec.ts
@@ -35,6 +35,25 @@ describe('Create Custom Projects - Setup', () => {
         });
 
       expect(response.status).toBe(200);
+      expect(response.body.data).toEqual({
+        Conservation: {
+          ecosystemLossRate: expect.any(Number),
+          emissionFactor: {
+            tier1: expect.any(Number),
+            tier2: {
+              emissionFactorAgb: expect.any(Number),
+              emissionFactorSoc: expect.any(Number),
+            },
+          },
+        },
+        Restoration: {
+          sequestrationRate: {
+            tier1: expect.any(Number),
+            tier2: expect.any(Number),
+          },
+          plantingSuccessRate: expect.any(Number),
+        },
+      });
     });
   });
 

--- a/shared/dtos/custom-projects/activity-types-defaults.ts
+++ b/shared/dtos/custom-projects/activity-types-defaults.ts
@@ -12,11 +12,11 @@ export type ConvervationActivityDefaults = {
 };
 
 export type RestorationActivityDefaults = {
-  activity: string;
   sequestrationRate: {
     tier1: number;
     tier2: number;
   };
+  plantingSuccessRate: number
 };
 
 export type ActivityTypesDefaults = {


### PR DESCRIPTION
**This PR adds Planting Success Rate assumption to the activity defaults endpoint, so it can be dyamically populated in the custom project creation form**

Relevant ticket: https://vizzuality.atlassian.net/browse/TBCCT-406

This pull request introduces changes to enhance the handling of restoration activity data by including a new `plantingSuccessRate` field and updating related logic, tests, and data structures. The most important changes focus on improving the repository method, updating the test suite, and modifying the DTOs to support the new field.

### Enhancements to restoration activity handling:

* **Repository logic update**:
  - In `data.repository.ts`, replaced the `findOne` method with `findOneOrFail` for retrieving restoration activity data and added a query to fetch the `plantingSuccessRate` from the assumptions repository. The `activity` field was removed from the selected fields, and the new `plantingSuccessRate` is now included in the returned object.

* **Integration test update**:
  - In `custom-projects-setup.spec.ts`, extended the test to validate the presence and structure of the new `plantingSuccessRate` field in the response body for restoration activities.

* **DTO modification**:
  - In `activity-types-defaults.ts`, updated the `RestorationActivityDefaults` type to include the `plantingSuccessRate` field and removed the unused `activity` field.