### PR TITLE
[TBCCT-383] fixes undefined lossRate in restoration projects

### DIFF
--- a/client/src/containers/projects/form/setup/activity/index.tsx
+++ b/client/src/containers/projects/form/setup/activity/index.tsx
@@ -22,11 +22,14 @@ import { ACTIVITIES } from "@/containers/overview/filters/constants";
 import { useFormValues } from "@/containers/projects/form/project-form";
 import { useCustomProjectForm } from "@/containers/projects/form/utils";
 
-import { FormItem, FormLabel } from "@/components/ui/form";
-import { FormControl } from "@/components/ui/form";
-import { FormField, FormMessage } from "@/components/ui/form";
-import { RadioGroup } from "@/components/ui/radio-group";
-import { RadioGroupItemBox } from "@/components/ui/radio-group";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { RadioGroup, RadioGroupItemBox } from "@/components/ui/radio-group";
 
 type RestorationParameters = z.infer<typeof RestorationCustomProjectSchema>;
 type ConservationParameters = z.infer<typeof ConservationCustomProjectSchema>;
@@ -89,6 +92,14 @@ export default function Activity() {
         DEFAULT_CONSERVATION_FORM_VALUES.parameters.projectSpecificEmission,
       );
       form.trigger("parameters.projectSpecificEmission");
+    }
+
+    if ((parameters as ConservationParameters).lossRateUsed === undefined) {
+      form.setValue(
+        "parameters.lossRateUsed",
+        DEFAULT_CONSERVATION_FORM_VALUES.parameters.lossRateUsed,
+      );
+      form.trigger("parameters.lossRateUsed");
     }
   }, [form, parameters, assumptions?.restorationRate]);
   const handleOnValueChange = async (v: string) => {

--- a/client/src/containers/projects/form/setup/conservation-project-details/index.tsx
+++ b/client/src/containers/projects/form/setup/conservation-project-details/index.tsx
@@ -73,7 +73,7 @@ export default function ConservationProjectDetails() {
                 <div className="relative flex items-center">
                   <RadioGroup
                     className="flex gap-4"
-                    defaultValue={
+                    value={
                       form.getValues(
                         "parameters.lossRateUsed",
                       ) as LOSS_RATE_USED
@@ -91,7 +91,7 @@ export default function ConservationProjectDetails() {
                             // @ts-expect-error fix later
                             form.formState.defaultValues?.parameters?.projectSpecificLossRate
                             // @ts-expect-error fix later
-                          : form.getValues().parameters?.projectSpecificLossRate,
+                            : form.getValues().parameters?.projectSpecificLossRate,
                         );
                       }
 

--- a/e2e/lib/utils.ts
+++ b/e2e/lib/utils.ts
@@ -40,6 +40,15 @@ const createAndSaveCustomProject = async (page: Page) => {
   await page.getByRole("button", { name: "Save project" }).click();
 };
 
+
+const createAndSaveRestorationCustomProject = async (page: Page) => {
+  await page.goto(ROUTES.projects.new);
+  await insertProjectName(page);
+  await page.getByLabel("Restoration").click();
+  await submitCustomProject(page);
+  await page.getByRole("button", { name: "Save project" }).click();
+};
+
 const navigateToEditCustomProject = async (page: Page) => {
   await page.getByTestId("edit-project-link").click();
 };
@@ -65,6 +74,7 @@ export {
   insertProjectSpecificLossRate,
   submitCustomProject,
   createAndSaveCustomProject,
+  createAndSaveRestorationCustomProject,
   navigateToEditCustomProject,
   getDataFromNetworkRequest,
   expectEditProjectHeadingVisible,


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/TBCCT-383

This pull request introduces several updates to the project setup and testing workflows, focusing on improving form handling, adding new utility functions, and enhancing test reliability. Key changes include refactoring imports, adding default values for form parameters, introducing a new utility for restoration projects, and updating Playwright tests for better consistency and coverage.

### Updates to form handling:
* Consolidated imports in `client/src/containers/projects/form/setup/activity/index.tsx` for better readability and maintenance.
* Added logic to set a default value for the `lossRateUsed` parameter in the `Activity` component when undefined, ensuring consistent form behavior.
* Updated the `RadioGroup` component in `ConservationProjectDetails` to use the `value` prop instead of `defaultValue` for better reactivity.

### Enhancements to utilities:
* Added a new utility function, `createAndSaveRestorationCustomProject`, to streamline the creation of restoration projects in tests. [[1]](diffhunk://#diff-9d0a82dbceec3056474f1e1ce7b150edf0e7346863aff46b43cbfb6798c269caR43-R51) [[2]](diffhunk://#diff-9d0a82dbceec3056474f1e1ce7b150edf0e7346863aff46b43cbfb6798c269caR77)

### Improvements to Playwright tests:
* Refactored test imports for consistency and readability in `e2e/tests/custom-projects/edit-custom-project.spec.ts`.
* Replaced synchronous `expect` calls with `await expect` in multiple assertions to ensure proper asynchronous handling. [[1]](diffhunk://#diff-5071bb65859507693e61bca9006912299976d2a63a4e90f855ce9fc99ee8b057L40-R46) [[2]](diffhunk://#diff-5071bb65859507693e61bca9006912299976d2a63a4e90f855ce9fc99ee8b057L71-R70) [[3]](diffhunk://#diff-5071bb65859507693e61bca9006912299976d2a63a4e90f855ce9fc99ee8b057L82-R81) [[4]](diffhunk://#diff-5071bb65859507693e61bca9006912299976d2a63a4e90f855ce9fc99ee8b057L98-R97) [[5]](diffhunk://#diff-5071bb65859507693e61bca9006912299976d2a63a4e90f855ce9fc99ee8b057L111-R110) [[6]](diffhunk://#diff-5071bb65859507693e61bca9006912299976d2a63a4e90f855ce9fc99ee8b057L128-R142)
* Added a new test to verify that the "Project specific loss rate used" option is selected by default when switching from a restoration to a conservation project.