### PR TITLE
[TBCCT-410] replaces "Community benefit sharing fund" with "Landowner/community benefit share"

### DIFF
--- a/api/test/integration/custom-projects/custom-projects-save.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-save.spec.ts
@@ -79,7 +79,7 @@ describe('Snapshot Custom Projects', () => {
               'Funding gap': 493830.3621939037,
               'Funding gap (NPV)': 493830.3621939037,
               'Funding gap per tCO2e (NPV)': 18.965162372675024,
-              'Community benefit sharing fund': 0.5,
+              'Landowner/community benefit share': 0.5,
             },
             costDetails: {
               total: {

--- a/client/src/containers/methodology/table/data.tsx
+++ b/client/src/containers/methodology/table/data.tsx
@@ -216,9 +216,9 @@ export const projectCostsAssumptionsAndMethodologyData = {
       category: "opex",
     },
     {
-      id: "project-costs-assumptions-and-methodology-community-benefit-sharing-fund",
+      id: "project-costs-assumptions-and-methodology-landowner/community-benefit-share",
       costComponent: (
-        <p className="font-bold">Community benefit sharing fund</p>
+        <p className="font-bold">Landowner/community benefit share</p>
       ),
       costAssumption:
         "5% of carbon credit revenues (developed countries), 50%-85% (developing country)",

--- a/client/src/containers/overview/project-details/utils.ts
+++ b/client/src/containers/overview/project-details/utils.ts
@@ -30,7 +30,7 @@ const costEstimatesLabelMap: Record<
   opex: "Operating expenditure",
   monitoring: "Monitoring",
   maintenance: "Maintenance",
-  communityBenefit: "Community benefit sharing fund",
+  communityBenefit: "Landowner/community benefit share",
   carbonStandardFees: "Carbon standard fees",
   baselineReassessment: "Baseline reassessment",
   mrv: "MRV",

--- a/client/src/containers/overview/table/toolbar/index.tsx
+++ b/client/src/containers/overview/table/toolbar/index.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 
-import { SCORECARD_PRIORITIZATION, KEY_COSTS } from "@/constants/tooltip";
+import { KEY_COSTS, SCORECARD_PRIORITIZATION } from "@/constants/tooltip";
 
 import SearchProjectsTable from "@/containers/overview/table/toolbar/search";
 import TabsProjectsTable from "@/containers/overview/table/toolbar/table-selector";
@@ -9,13 +9,13 @@ import InfoButton from "@/components/ui/info-button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Table,
-  TableHeader,
-  TableRow,
-  TableHead,
   TableBody,
   TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface ScorecardMetric {
   name: string;
@@ -75,7 +75,7 @@ const KEY_COSTS_DATA: KeyCost[] = [
     description: "IMPLEMENTATION_LABOR",
   },
   {
-    name: "Community benefit sharing fund",
+    name: "Landowner/community benefit share",
     description: "COMMUNITY_BENEFIT_SHARING_FUND",
   },
   {

--- a/client/src/hooks/use-custom-project-output.ts
+++ b/client/src/hooks/use-custom-project-output.ts
@@ -123,9 +123,6 @@ export const useCustomProjectOutput = (
       "IRR when priced to cover OpEx": parseFloat(
         toPercentageValue(output.summary["IRR when priced to cover OpEx"]),
       ),
-      "Community benefit sharing fund": parseFloat(
-        toPercentageValue(output.summary["Landowner/community benefit share"]),
-      ),
     };
   }, [output?.summary]);
   const leftOverProps = useMemo(() => {

--- a/client/tests/projects/form/constants.ts
+++ b/client/tests/projects/form/constants.ts
@@ -70,7 +70,7 @@ export const FAKE_PROJECT = {
       "Funding gap per tCO2e (NPV)": -8.110001226263627,
       "Operating expenditure (NPV)": -2.739651474795e33,
       "IRR when priced to cover OpEx": 33.40846607519514,
-      "Community benefit sharing fund": 0.5,
+      "Landowner/community benefit share": 0.5,
       "Total revenue (non-discounted)": -1.338766124151795e34,
       "Leftover after OpEx / total cost": null,
       "IRR when priced to cover total cost": 91.02860607863423,


### PR DESCRIPTION
Task: https://vizzuality.atlassian.net/browse/TBCCT-410

This pull request standardizes terminology across the codebase by replacing the term "Community benefit sharing fund" with "Landowner/community benefit share" in various files. The changes ensure consistency in naming conventions and remove redundant code related to the old terminology.

### Terminology Standardization:

* [`api/test/integration/custom-projects/custom-projects-save.spec.ts`](diffhunk://#diff-124179fd0dc8dfe83a9603ea28faa3eccc0706bfec20acf39bf1d89c1a4b42c9L82-R82): Updated the key `'Community benefit sharing fund'` to `'Landowner/community benefit share'` in test data.
* [`client/src/containers/methodology/table/data.tsx`](diffhunk://#diff-c8936b71b4513d5225c2f44ae0773f42d7685dead6acf5609fa5b256e65ee93bL219-R221): Renamed the `id` and updated the display text for the cost component from "Community benefit sharing fund" to "Landowner/community benefit share".
* [`client/tests/projects/form/constants.ts`](diffhunk://#diff-ce722923928cf9bbeffa7f1fb6318ef3a646394a94ff9f07b01bab6bad8489b9L73-R73): Replaced the key `'Community benefit sharing fund'` with `'Landowner/community benefit share'` in the fake project data.

### Code Simplification:

* [`client/src/hooks/use-custom-project-output.ts`](diffhunk://#diff-f4164edac9e59b332f842d6c60825a2d64812f6fdf01802576b3827926aa877eL126-L128): Removed redundant parsing logic for the old "Community benefit sharing fund" key in the `useCustomProjectOutput` hook.
