### PR TITLE
Bugfix/missing first negative year restoration plan

### DIFF
--- a/api/src/modules/custom-projects/input-factory/custom-project.factory.ts
+++ b/api/src/modules/custom-projects/input-factory/custom-project.factory.ts
@@ -91,6 +91,15 @@ export class CustomProjectFactory {
       costInputs,
       additionalBaseData,
     );
+
+    // TODO: This is a workaround as it seems that planting success rate is defined as parameter, and it was previously a non overridable assumption
+    //       However, now we need to use this as overridable assumption. To make this right:
+    //       1. we need to remove it from the non overridable assumptions definition
+    //       2. the FE should send it as assumption instead of parameter
+    if (projectParams.plantingSuccessRate) {
+      additionalAssumptions.plantingSuccessRate =
+        projectParams.plantingSuccessRate;
+    }
     restorationProjectInput.setModelAssumptions(
       assumptions,
       additionalAssumptions,

--- a/api/src/modules/custom-projects/input-factory/restoration-project.input.ts
+++ b/api/src/modules/custom-projects/input-factory/restoration-project.input.ts
@@ -142,9 +142,13 @@ export class RestorationProjectInput {
       planMap.set(year, annualHectaresRestored);
     }
 
-    // The plan that can be modified by the user starts at year 1 and does not have to be continuous
-    // TODO!!!: According to science example, the missing years are filled with 0! Double check this
-    for (let year = 1; year <= projectLength; year++) {
+    // The plan that can be modified by the user starts at year -1 and does not have to be continuous.
+    // We the missing years with 0
+    for (let year = -1; year <= projectLength; year++) {
+      // Ignore year 0, as it is not a valid year for restoration
+      if (year === 0) {
+        continue;
+      }
       result[year] = planMap.get(year) ?? 0;
     }
 


### PR DESCRIPTION
 fixes:

1. error when -1 year is provided as custom restoration plan
2. introduces a hack to override planting success rate as model assumption:
This is a workaround as it seems that planting success rate is defined as parameter, and it was previously a non overridable assumption
     However, now we need to use this as overridable assumption. To make this right:
      1. we need to remove it from the non overridable assumptions definition
      2. the FE should send it as assumption instead of parameter