### PR TITLE
[TBCCT-424] cost details: moves implementation labor cost to capital expenditure

### DIFF
--- a/client/src/containers/projects/custom-project/cost-details/table/utils.ts
+++ b/client/src/containers/projects/custom-project/cost-details/table/utils.ts
@@ -31,10 +31,11 @@ const CONSERVATION_PROJECT_COST_LABELS: Record<
 const RESTORATION_PROJECT_COST_LABELS: Record<
   keyof CustomProjectCostDetails,
   string
-> = {
-  ...CONSERVATION_PROJECT_COST_LABELS,
-  implementationLabor: "Implementation labor",
-} as const;
+> = Object.fromEntries([
+  ...Object.entries(CONSERVATION_PROJECT_COST_LABELS).slice(0, 6),
+  ...Object.entries({ implementationLabor: "Implementation labor" }),
+  ...Object.entries(CONSERVATION_PROJECT_COST_LABELS).slice(6),
+]) as Record<keyof CustomProjectCostDetails, string>;
 
 function parseCostDetailsForTable(
   activity: ACTIVITY,


### PR DESCRIPTION
Task: https://vizzuality.atlassian.net/browse/TBCCT-424

This pull request modifies the way `RESTORATION_PROJECT_COST_LABELS` is constructed in the `utils.ts` file to improve flexibility and maintainability. The change replaces a static object spread pattern with a dynamic approach using `Object.fromEntries` and array slicing.

### Key changes:

#### Code restructuring for flexibility:
* [`client/src/containers/projects/custom-project/cost-details/table/utils.ts`](diffhunk://#diff-b7531b4a5e9fe352796c5ca575121807b801f16daad98dfab74d901e1cf71b5fL34-R38): Updated the `RESTORATION_PROJECT_COST_LABELS` definition to dynamically merge entries from `CONSERVATION_PROJECT_COST_LABELS` with the new `implementationLabor` label. This is achieved by slicing and recombining entries, allowing for better control over label ordering.