### PR TITLE
[N/A] updates project-specific loss rate range

### DIFF
--- a/api/test/integration/custom-projects/custom-projects-validations.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-validations.spec.ts
@@ -108,7 +108,7 @@ describe('Create Custom Projects - Request Validations', () => {
       );
       expect(expectedError).toBeDefined();
     });
-    test('If Project Specific Loss rate value is not within -0.3%, -0.001%, should fail', async () => {
+    test('If Project Specific Loss rate value is not within -100% - 0%, should fail', async () => {
       const response = await testManager
         .request()
         .post(customProjectContract.createCustomProject.path)
@@ -122,7 +122,7 @@ describe('Create Custom Projects - Request Validations', () => {
           carbonRevenuesToCover: 'Opex',
           parameters: {
             lossRateUsed: 'Project specific',
-            projectSpecificLossRate: -0.004,
+            projectSpecificLossRate: -1.1,
             emissionFactorUsed: PROJECT_EMISSION_FACTORS.TIER_2,
             projectSpecificEmission: 'One emission factor',
           },
@@ -157,7 +157,7 @@ describe('Create Custom Projects - Request Validations', () => {
       expect(response.status).toEqual(400);
 
       expect(response.body.errors[0].title).toEqual(
-        'Project Specific Loss Rate must be between -0.3% and -0.001%',
+        'Project Specific Loss Rate must be between -100% and 0%',
       );
     });
     test('If Emission Factor Used is Tier 2, only Mangroves is accepted as ecosystem', async () => {

--- a/client/src/containers/projects/form/number-form-item.tsx
+++ b/client/src/containers/projects/form/number-form-item.tsx
@@ -1,6 +1,6 @@
-import { useState, ChangeEvent, useEffect } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
-import { toPercentageValue, toDecimalPercentageValue } from "@/lib/format";
+import { toDecimalPercentageValue, toPercentageValue } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 import {
@@ -91,7 +91,6 @@ export default function NumberFormItem({
             <Input
               type="number"
               className="w-full pr-12"
-              min={0}
               value={state}
               onChange={handleOnChange}
               placeholder={placeholder || "Insert value"}

--- a/client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx
+++ b/client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx
@@ -88,7 +88,6 @@ export default function LossRate() {
               )}
               formItemClassName="flex items-center justify-between gap-4"
               formControlClassName="after:content-['%']"
-              max={0}
               onValueChange={async (v) =>
                 handleFormChange("parameters.projectSpecificLossRate", v)
               }

--- a/e2e/tests/custom-projects/create-custom-project.spec.ts
+++ b/e2e/tests/custom-projects/create-custom-project.spec.ts
@@ -1,12 +1,8 @@
-import { Page, test, expect, Locator } from "@playwright/test";
+import { expect, Locator, Page, test } from "@playwright/test";
 import { ACTIVITY } from "@shared/entities/activity.enum";
 import { E2eTestManager } from "@shared/lib/e2e-test-manager";
 import { EXTENDED_TIMEOUT, ROUTES } from "e2e/lib/constants";
-import {
-  insertProjectName,
-  insertProjectSpecificLossRate,
-  submitCustomProject,
-} from "e2e/lib/utils";
+import { insertProjectName, insertProjectSpecificLossRate, submitCustomProject } from "e2e/lib/utils";
 
 let testManager: E2eTestManager;
 let page: Page;
@@ -48,7 +44,7 @@ test.describe("Custom Projects - Create", () => {
     test("The correct errors are displayed upon invalid form submission", async () => {
       const defaultErrorMessages = [
         "Name must contain at least 3 characters.",
-        "required",
+        "Project Specific Loss Rate must be between -100% and 0%",
       ];
       const errorMessages = ["Name must contain at least 3 characters."];
 

--- a/shared/schemas/custom-projects/create-custom-project.schema.ts
+++ b/shared/schemas/custom-projects/create-custom-project.schema.ts
@@ -35,7 +35,7 @@ export const ConservationCustomProjectSchema = z.object({
               {
                 message: "Project Specific Loss Rate must be between -100% and 0%",
               }
-          )
+          ).optional(),
   ),
   projectSpecificEmissionFactor: z
     .number({
@@ -223,10 +223,10 @@ export const ValidateConservationSchema = (
     typeof ConservationCustomProjectSchema
   >;
   if (params.lossRateUsed === LOSS_RATE_USED.PROJECT_SPECIFIC) {
-    if (!params.projectSpecificLossRate) {
+    if (params.projectSpecificLossRate === undefined || params.projectSpecificLossRate === null) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "required",
+        message: "Project Specific Loss Rate must be between -100% and 0%",
         path: ["parameters.projectSpecificLossRate"],
       });
     }

--- a/shared/schemas/custom-projects/create-custom-project.schema.ts
+++ b/shared/schemas/custom-projects/create-custom-project.schema.ts
@@ -31,12 +31,11 @@ export const ConservationCustomProjectSchema = z.object({
             invalid_type_error: "Project Specific Loss Rate should be a number",
           })
           .refine(
-              (val) => val >= -0.003 && val <= -0.00001,
+              (val) => val >= -1 && val <= 0,
               {
-                message: "Project Specific Loss Rate must be between -0.3% and -0.001%",
+                message: "Project Specific Loss Rate must be between -100% and 0%",
               }
           )
-          .optional()
   ),
   projectSpecificEmissionFactor: z
     .number({


### PR DESCRIPTION
This pull request updates the validation rules for "Project Specific Loss Rate" across the codebase to expand the acceptable range from `-0.3% to -0.001%` to `-100% to 0%`. It also includes minor refactoring changes to improve code readability and consistency in import ordering.

### Validation Rules Update:

* [`api/test/integration/custom-projects/custom-projects-validations.spec.ts`](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012L111-R111): Updated test cases to reflect the new validation range for "Project Specific Loss Rate" and adjusted test data accordingly. [[1]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012L111-R111) [[2]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012L125-R125) [[3]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012L160-R160)
* [`shared/schemas/custom-projects/create-custom-project.schema.ts`](diffhunk://#diff-e2acc2e0e44826a98602752f24e3062f9cfd0526a60190ad2f8b02d0127fdbf0L34-R38): Modified the schema validation logic to enforce the new range and updated error messages to match the expanded range. [[1]](diffhunk://#diff-e2acc2e0e44826a98602752f24e3062f9cfd0526a60190ad2f8b02d0127fdbf0L34-R38) [[2]](diffhunk://#diff-e2acc2e0e44826a98602752f24e3062f9cfd0526a60190ad2f8b02d0127fdbf0L227-R229)
* [`e2e/tests/custom-projects/create-custom-project.spec.ts`](diffhunk://#diff-d793a914c7499b4d7e9434f1935e5ede524ed2ff97d4e6642f5666bad15db1d7L51-R47): Updated error messages in end-to-end tests to align with the new validation rules.

### Refactoring Changes:

* [`client/src/containers/projects/form/number-form-item.tsx`](diffhunk://#diff-ed1c54bcd0b22c597dd42782108ac020f048325ced6035e465757fb93ac92ec0L1-R3): Reordered imports for consistency and removed the `min` attribute from the input field, as it is no longer relevant given the new validation rules. [[1]](diffhunk://#diff-ed1c54bcd0b22c597dd42782108ac020f048325ced6035e465757fb93ac92ec0L1-R3) [[2]](diffhunk://#diff-ed1c54bcd0b22c597dd42782108ac020f048325ced6035e465757fb93ac92ec0L94)
* [`client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx`](diffhunk://#diff-d56e9772dbf818cd3ac8c9c7b613c4496d40aa91d066b5f4e068749fb96987a5L91): Removed the `max` attribute from the input field to align with the updated validation range.
* [`e2e/tests/custom-projects/create-custom-project.spec.ts`](diffhunk://#diff-d793a914c7499b4d7e9434f1935e5ede524ed2ff97d4e6642f5666bad15db1d7L1-R5): Reordered imports for improved readability.