### PR TITLE
[TBCCT-431] disables T2 sequestration rate option when Mangroves ecosystem is not selected

### DIFF
--- a/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
+++ b/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
@@ -76,6 +76,16 @@ export default function RestorationProjectDetails() {
       ].includes(activity),
   }));
 
+  const SEQUESTRATION_RATE_TIER_OPTIONS = Object.values(
+    SEQUESTRATION_RATE_TIER_TYPES,
+  ).map((tier) => ({
+    value: tier,
+    label: tier,
+    disabled:
+      tier === SEQUESTRATION_RATE_TIER_TYPES.TIER_2 &&
+      ecosystem !== ECOSYSTEM.MANGROVE,
+  }));
+
   return (
     <Card variant="secondary">
       <div className="flex flex-col gap-4">
@@ -151,23 +161,21 @@ export default function RestorationProjectDetails() {
                           v as SEQUESTRATION_RATE_TIER_TYPES,
                         );
                         await form.trigger("parameters.tierSelector");
-
-                        if (v === SEQUESTRATION_RATE_TIER_TYPES.TIER_2) {
-                          form.setValue("ecosystem", ECOSYSTEM.MANGROVE);
-                        }
                       }}
                     >
                       <SelectTrigger data-testid="parameters.tierSelector">
                         <SelectValue placeholder="Select sequestration tier" />
                       </SelectTrigger>
                       <SelectContent>
-                        {Object.values(SEQUESTRATION_RATE_TIER_TYPES)?.map(
-                          (option) => (
-                            <SelectItem key={option} value={option}>
-                              {option}
-                            </SelectItem>
-                          ),
-                        )}
+                        {SEQUESTRATION_RATE_TIER_OPTIONS?.map((option) => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                            disabled={option.disabled}
+                          >
+                            {option.label}
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                   </FormControl>

--- a/e2e/tests/custom-projects/create-custom-project.spec.ts
+++ b/e2e/tests/custom-projects/create-custom-project.spec.ts
@@ -223,16 +223,11 @@ test.describe("Custom Projects - Create", () => {
       ).toBeVisible();
 
       await page.getByTestId("parameters.tierSelector").click();
-      await page
+      await expect(page
         .getByRole("option", {
           name: "Tier 2 - Country-specific rate",
-        })
-        .click();
-      await expect(
-        page.locator("label", { hasText: "Country-specific rate" }),
-      ).toBeVisible();
+        })).toBeDisabled()
 
-      await page.getByTestId("parameters.tierSelector").click();
       await page
         .getByRole("option", {
           name: "Tier 3 - Project-specific rate",


### PR DESCRIPTION
This pull request refactors the sequestration rate tier selection logic in the `RestorationProjectDetails` component to improve maintainability and enhance functionality. The changes include the introduction of a new `SEQUESTRATION_RATE_TIER_OPTIONS` constant for tier options and the removal of hardcoded logic for ecosystem defaults.

### Refactoring for maintainability:

* [`client/src/containers/projects/form/setup/restoration-project-detail/index.tsx`](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eR79-R88): Added a `SEQUESTRATION_RATE_TIER_OPTIONS` constant that dynamically generates tier options with labels and disabled states based on the ecosystem type. This replaces hardcoded tier logic.

### Enhancements to functionality:

* [`client/src/containers/projects/form/setup/restoration-project-detail/index.tsx`](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL154-R178): Updated the tier selection dropdown to use `SEQUESTRATION_RATE_TIER_OPTIONS`, allowing for dynamic disabling of options based on the ecosystem type. Removed the hardcoded default ecosystem assignment for `TIER_2`.