### PR TITLE
[TBCCT-428] brings breakeven line forward in chart

### DIFF
--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
@@ -8,18 +8,18 @@ import {
   CartesianGrid,
   ComposedChart,
   Line,
+  ReferenceLine,
   XAxis,
   YAxis,
-  ReferenceLine,
 } from "recharts";
 
 import { formatCurrency } from "@/lib/format";
 
 import {
-  YearlyBreakdownChartData,
+  cashflowConfig,
   cumulativeNetIncomePlanTooltipLabel,
+  YearlyBreakdownChartData,
 } from "@/containers/projects/custom-project/annual-project-cash-flow/utils";
-import { cashflowConfig } from "@/containers/projects/custom-project/annual-project-cash-flow/utils";
 
 import {
   ChartContainer,
@@ -91,9 +91,7 @@ const CashflowChart: FC<CashflowChartProps> = ({
           horizontal={true}
           vertical={true}
         />
-        {typeof breakevenPoint === "number" && (
-          <ReferenceLine x={breakevenPoint} stroke="hsl(var(--destructive))" />
-        )}
+
         <YAxis
           axisLine={false}
           tickLine={false}
@@ -123,6 +121,9 @@ const CashflowChart: FC<CashflowChartProps> = ({
           fill={CHART_COLORS.capexTotalCostPlan}
           radius={[6, 6, 0, 0]}
         />
+        {typeof breakevenPoint === "number" && (
+          <ReferenceLine x={breakevenPoint} stroke="hsl(var(--destructive))" />
+        )}
         <Line
           type="linear"
           dataKey="annualNetCashFlow"


### PR DESCRIPTION
This pull request makes adjustments to the `CashflowChart` component in `client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx`, including reordering imports and relocating the `ReferenceLine` rendering logic to improve code organization and readability.

### Import Reorganization:
* Reordered the imports to group related items together and ensure consistent organization. Specifically, moved `ReferenceLine` within the `recharts` imports and adjusted the order of utility imports.

### Code Organization Improvements:
* Removed the `ReferenceLine` rendering logic from its previous position and relocated it to a later part of the `CashflowChart` component, ensuring it appears after the `Bar` elements are defined. This improves the logical flow of rendering and aligns with visual hierarchy. [[1]](diffhunk://#diff-4112bb32fabe66d8f06a4729f30c49ff9d3226de975b22ec06ed98be8da0c07fL94-R94) [[2]](diffhunk://#diff-4112bb32fabe66d8f06a4729f30c49ff9d3226de975b22ec06ed98be8da0c07fR124-R126)