### PR TITLE
[TBCCT-432] updates unit and description of Tier 2 - Country-specific rate

### DIFF
--- a/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
+++ b/client/src/containers/projects/form/setup/restoration-project-detail/index.tsx
@@ -231,12 +231,13 @@ export default function RestorationProjectDetails() {
                   <FormLabel
                     tooltip={{
                       title: SEQUESTRATION_RATE_TIER_TYPES.TIER_2,
-                      content: "TBD",
+                      content:
+                        "Growth rate and carbon accumulation rate in soils.",
                     }}
                   >
                     Country-specific rate
                   </FormLabel>
-                  <div className="relative flex flex-1 items-center after:absolute after:right-6 after:inline-block after:text-sm after:text-muted-foreground after:content-['??']">
+                  <div className="relative flex flex-1 items-center after:absolute after:right-6 after:inline-block after:text-sm after:text-muted-foreground after:content-['tCO2e/ha/yr']">
                     <ReadonlyInput value={formatNumber(data?.tier2)} />
                   </div>
                 </div>


### PR DESCRIPTION
This pull request makes a small update to the `RestorationProjectDetails` component to improve the clarity of displayed information. Specifically, it updates tooltip content and the placeholder text for a data field.

### Changes in `RestorationProjectDetails` component:

* Updated the tooltip content to provide a more descriptive explanation: "Growth rate and carbon accumulation rate in soils." (`client/src/containers/projects/form/setup/restoration-project-detail/index.tsx`, [client/src/containers/projects/form/setup/restoration-project-detail/index.tsxL234-R240](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL234-R240))
* Changed the placeholder text for the `ReadonlyInput` field to "tCO2e/ha/yr" for better context. (`client/src/containers/projects/form/setup/restoration-project-detail/index.tsx`, [client/src/containers/projects/form/setup/restoration-project-detail/index.tsxL234-R240](diffhunk://#diff-d2d621298d4d4d9f5b677461c9bde02aec797b48304634606cca5ea07ae5207eL234-R240))