### PR TITLE
[TBCCT-345] sends projectSpecificLossRate without percentage formatting

### DIFF
--- a/client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx
+++ b/client/src/containers/projects/form/setup/conservation-project-details/loss-rate.tsx
@@ -91,7 +91,6 @@ export default function LossRate() {
               onValueChange={async (v) =>
                 handleFormChange("parameters.projectSpecificLossRate", v)
               }
-              isPercentage
             />
           )}
         />


### PR DESCRIPTION
This pull request includes a small change to the `LossRate` component in `loss-rate.tsx`. The `isPercentage` prop was removed from the component's usage, simplifying its implementation.