### PR TITLE
feat: Add "Total abatement potential (tCO2e, without buffer)" in custom-project-output.dto.ts

### DIFF
--- a/shared/dtos/custom-projects/custom-project-output.dto.ts
+++ b/shared/dtos/custom-projects/custom-project-output.dto.ts
@@ -32,6 +32,7 @@ const SORTED_CUSTOM_PROJECT_SUMMARY_KEYS = [
   "Capital expenditure (NPV)",
   "Operating expenditure (NPV)",
   "Credits issued",
+  "Total abatement potential (tCO2e, without buffer)",
   "Total revenue (NPV)",
   "Total revenue (non-discounted)",
   "Financing cost",


### PR DESCRIPTION
This pull request updates the `SORTED_CUSTOM_PROJECT_SUMMARY_KEYS` array in the `shared/dtos/custom-projects/custom-project-output.dto.ts` file to include a new key for better project summary reporting.

Key addition:

* Added `"Total abatement potential (tCO2e, without buffer)"` to the `SORTED_CUSTOM_PROJECT_SUMMARY_KEYS` array to enhance the representation of project metrics.