### PR TITLE
[TBCCT-456] updates text of map's tooltip

### DIFF
--- a/client/src/containers/overview/map/popup/index.tsx
+++ b/client/src/containers/overview/map/popup/index.tsx
@@ -24,8 +24,12 @@ export default function CostAbatementPopup() {
       <table className="mt-2">
         <thead>
           <tr>
-            <th className={cn(HEADER_CLASSES, "pr-2")}>AVG Cost (USD)</th>
-            <th className={cn(HEADER_CLASSES, "px-2")}>Abatement (tCO2e)</th>
+            <th className={cn(HEADER_CLASSES, "pr-2")}>
+              Ave Cost per credit (USD/tCO2e)
+            </th>
+            <th className={cn(HEADER_CLASSES, "px-2")}>
+              Abatement potential (tCO2e)
+            </th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This pull request updates the `CostAbatementPopup` component to improve clarity in the table headers. 

Changes to table headers in `CostAbatementPopup`:

* Updated the header text for average cost to "Ave Cost per credit (USD/tCO2e)" for better specificity.
* Updated the header text for abatement to "Abatement potential (tCO2e)" to enhance clarity regarding the data displayed.