### PR TITLE
[TBCCT-442] scorecard prioritization: keeps arrow sizes consistent

### DIFF
--- a/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
+++ b/client/src/containers/overview/table/view/scorecard-prioritization/index.tsx
@@ -141,10 +141,12 @@ export function ScoredCardPrioritizationTable() {
                           header.getContext(),
                         )}
                         {{
-                          asc: <ChevronUpIcon className="h-4 w-4" />,
-                          desc: <ChevronDownIcon className="h-4 w-4" />,
+                          asc: <ChevronUpIcon className="h-4 w-4 shrink-0" />,
+                          desc: (
+                            <ChevronDownIcon className="h-4 w-4 shrink-0" />
+                          ),
                         }[header.column.getIsSorted() as string] ?? (
-                          <ChevronsUpDownIcon className="h-4 w-4" />
+                          <ChevronsUpDownIcon className="h-4 w-4 shrink-0" />
                         )}
                       </div>
                     )}


### PR DESCRIPTION
This pull request includes a small change to the `ScoredCardPrioritizationTable` component in `index.tsx`. The change ensures consistent layout behavior by adding the `shrink-0` class to the icons used for sorting.