### PR TITLE
[TBCCT-448] hides email leak and improves consistency of errors display

### DIFF
--- a/client/src/containers/auth/forgot-password/email-form/index.tsx
+++ b/client/src/containers/auth/forgot-password/email-form/index.tsx
@@ -33,7 +33,7 @@ const ForgotPasswordEmailForm: FC = () => {
       email: "",
     },
   });
-  const { apiResponseToast, toast } = useApiResponseToast();
+  const { toast } = useApiResponseToast();
 
   const handleForgotPassword = useCallback(
     (evt: FormEvent<HTMLFormElement>) => {
@@ -41,16 +41,13 @@ const ForgotPasswordEmailForm: FC = () => {
 
       form.handleSubmit(async (formValues) => {
         try {
-          const { status, body } =
-            await client.auth.requestPasswordRecovery.mutation({
-              body: formValues,
-            });
-          apiResponseToast(
-            { status, body },
-            {
-              successMessage: "Check your inbox for a password reset link.",
-            },
-          );
+          await client.auth.requestPasswordRecovery.mutation({
+            body: formValues,
+          });
+          toast({
+            description:
+              "An email has been sent to your inbox with a link to reset your password.",
+          });
         } catch (err) {
           toast({
             variant: "destructive",
@@ -61,7 +58,7 @@ const ForgotPasswordEmailForm: FC = () => {
         }
       })(evt);
     },
-    [form, apiResponseToast, toast],
+    [form, toast],
   );
 
   return (

--- a/client/src/containers/auth/signin/form/index.tsx
+++ b/client/src/containers/auth/signin/form/index.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { FC, FormEvent, useCallback, useRef, useState } from "react";
+import { FC, FormEvent, useCallback, useRef } from "react";
 
 import { useForm } from "react-hook-form";
 
 import Link from "next/link";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { LogInSchema } from "@shared/schemas/auth/login.schema";
@@ -26,6 +26,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toast/use-toast";
 
 interface SignInFormProps {
   onSignIn?: () => void;
@@ -33,7 +34,6 @@ interface SignInFormProps {
 const SignInForm: FC<SignInFormProps> = ({ onSignIn }) => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [errorMessage, setErrorMessage] = useState<string | undefined>("");
   const formRef = useRef<HTMLFormElement>(null);
   const form = useForm<z.infer<typeof LogInSchema>>({
     resolver: zodResolver(LogInSchema),
@@ -46,7 +46,6 @@ const SignInForm: FC<SignInFormProps> = ({ onSignIn }) => {
   const handleSignIn = useCallback(
     (evt: FormEvent<HTMLFormElement>) => {
       evt.preventDefault();
-      setErrorMessage(undefined);
 
       form.handleSubmit(async (formValues) => {
         try {
@@ -66,11 +65,17 @@ const SignInForm: FC<SignInFormProps> = ({ onSignIn }) => {
           }
 
           if (!response?.ok) {
-            setErrorMessage(response?.error ?? "unknown error");
+            toast({
+              description: response?.error ?? "unknown error",
+              variant: "destructive",
+            });
           }
         } catch (err) {
           if (err instanceof Error) {
-            setErrorMessage(err.message ?? "unknown error");
+            toast({
+              description: err.message ?? "unknown error",
+              variant: "destructive",
+            });
           }
         }
       })(evt);
@@ -115,9 +120,6 @@ const SignInForm: FC<SignInFormProps> = ({ onSignIn }) => {
             </FormItem>
           )}
         />
-        {errorMessage && (
-          <div className="text-center text-destructive">{errorMessage}</div>
-        )}
         <div className="flex justify-end">
           <Button variant="default" type="submit">
             Log in

--- a/e2e/tests/auth/delete-account.spec.ts
+++ b/e2e/tests/auth/delete-account.spec.ts
@@ -50,6 +50,6 @@ test.describe("Auth - Delete Account", () => {
     await page.locator('input[type="password"]').fill(user.password);
     await page.getByRole("button", { name: /log in/i }).click();
 
-    await expect(page.getByText("Invalid credentials")).toBeVisible();
+    await expect(page.getByText('Invalid credentials', { exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
This pull request refactors the handling of user notifications in the Forgot Password and Sign-In forms to streamline the code and improve user feedback. The changes primarily replace the use of state-based error messages with the `toast` notification system and simplify the code by removing unused variables.

### Forgot Password Form Changes:
* Replaced the `apiResponseToast` usage with the `toast` function for displaying success and error messages during the password recovery process.
* Updated the dependency array of the `handleForgotPassword` callback to remove the unused `apiResponseToast` dependency.

### Sign-In Form Changes:
* Removed the `useState` hook for managing error messages and replaced it with the `toast` function to handle error notifications. [[1]](diffhunk://#diff-57861ba932977f8ff3a960175e7fb1c6c7b761ffba3f8c7086138eb52d23ba9cR29-L36) [[2]](diffhunk://#diff-57861ba932977f8ff3a960175e7fb1c6c7b761ffba3f8c7086138eb52d23ba9cL49) [[3]](diffhunk://#diff-57861ba932977f8ff3a960175e7fb1c6c7b761ffba3f8c7086138eb52d23ba9cL69-R78)
* Deleted the JSX element that displayed error messages directly in the form, as errors are now shown using `toast`.
* Adjusted import order and removed unused imports for better code organization.