### PR TITLE
[TBCCT-446] fixes "cancel" button behavior

### DIFF
--- a/client/src/containers/projects/form/header.tsx
+++ b/client/src/containers/projects/form/header.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useFormContext } from "react-hook-form";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { ACTIVITY } from "@shared/entities/activity.enum";
@@ -156,7 +157,9 @@ export default function Header({ name, id }: HeaderProps) {
         </h2>
       </div>
       <div className="flex items-center gap-2">
-        <Button variant="secondary">Cancel</Button>
+        <Button variant="secondary" asChild>
+          <Link href={isEdit ? "/my-projects" : "/"}>Cancel</Link>
+        </Button>
         <Button
           onClick={() => {
             // Making sure only the necessary fields are included:


### PR DESCRIPTION
This pull request updates the `Header` component in `client/src/containers/projects/form/header.tsx` to improve navigation functionality. The most significant changes involve replacing the static "Cancel" button with a dynamic link and adding the `Link` component from `next/link`.

### Navigation improvements:

* Added an import for the `Link` component from `next/link` to enable dynamic navigation links. (`client/src/containers/projects/form/header.tsx`, [client/src/containers/projects/form/header.tsxR5](diffhunk://#diff-6d310098cf2ce4fffd28c7e3a9335452db99d36448f6fabc95d820db8ba48c7dR5))
* Updated the "Cancel" button to use the `Link` component, dynamically setting the `href` based on the `isEdit` condition. This ensures the button navigates to either `/my-projects` or `/`. (`client/src/containers/projects/form/header.tsx`, [client/src/containers/projects/form/header.tsxL159-R162](diffhunk://#diff-6d310098cf2ce4fffd28c7e3a9335452db99d36448f6fabc95d820db8ba48c7dL159-R162))