### PR TITLE
fix: Make model componets/factors read-only in the backoffice [TBCCT-459]

### DIFF
--- a/backoffice/resources/base-increase/base-increase.resource.ts
+++ b/backoffice/resources/base-increase/base-increase.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { BaseIncrease } from '@shared/entities/base-increase.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const BaseIncreaseResource: ResourceWithOptions = {
   resource: BaseIncrease,
@@ -15,6 +18,9 @@ export const BaseIncreaseResource: ResourceWithOptions = {
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/base-size/base-size.resource.ts
+++ b/backoffice/resources/base-size/base-size.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { BaseSize } from '@shared/entities/base-size.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const BaseSizeResource: ResourceWithOptions = {
   resource: BaseSize,
@@ -15,6 +18,9 @@ export const BaseSizeResource: ResourceWithOptions = {
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/baseline-reassesment/baseline-reassesment.resource.ts
+++ b/backoffice/resources/baseline-reassesment/baseline-reassesment.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { BaselineReassessment } from '@shared/entities/cost-inputs/baseline-reassessment.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const BaselineReassessmentResource: ResourceWithOptions = {
   resource: BaselineReassessment,
@@ -18,6 +21,9 @@ export const BaselineReassessmentResource: ResourceWithOptions = {
       baselineReassessmentCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/blue-carbon-project-planning/blue-carbon-project-planning.resource.ts
+++ b/backoffice/resources/blue-carbon-project-planning/blue-carbon-project-planning.resource.ts
@@ -1,6 +1,9 @@
 import { BlueCarbonProjectPlanning } from '@shared/entities/cost-inputs/blue-carbon-project-planning.entity.js';
 import { ResourceWithOptions } from 'adminjs';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 // position: number is not working in the options so we have to define the order of the columns using listProperties, showProperties and editProperties.
 const COLUMN_ORDER = ['countryCode', 'planningCost', 'source'];
@@ -21,6 +24,9 @@ export const BlueCarbonProjectPlanningResource: ResourceWithOptions = {
     navigation: {
       name: 'Model Components',
       icon: 'Settings',
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/carbon-estandard-fees/carbon-estandard-fees.resource.ts
+++ b/backoffice/resources/carbon-estandard-fees/carbon-estandard-fees.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { CarbonStandardFees } from '@shared/entities/cost-inputs/carbon-standard-fees.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const CarbonStandardFeesResource: ResourceWithOptions = {
   resource: CarbonStandardFees,
@@ -18,6 +21,9 @@ export const CarbonStandardFeesResource: ResourceWithOptions = {
       carbonStandardFee: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/carbon-righs/carbon-rights.resource.ts
+++ b/backoffice/resources/carbon-righs/carbon-rights.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { CarbonRights } from '@shared/entities/cost-inputs/establishing-carbon-rights.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const CarbonRightsResource: ResourceWithOptions = {
   resource: CarbonRights,
@@ -18,6 +21,9 @@ export const CarbonRightsResource: ResourceWithOptions = {
       carbonRightsCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/common/common.resources.ts
+++ b/backoffice/resources/common/common.resources.ts
@@ -21,3 +21,10 @@ export const COMMON_RESOURCE_LIST_PROPERTIES: ResourceOptions['properties'] = {
     isVisible: { list: true, show: true, edit: false, filter: true },
   },
 };
+
+export const DEFAULT_READONLY_PERMISSIONS: ResourceOptions['actions'] = {
+  new: { isVisible: false, isAccessible: false },
+  edit: { isVisible: false, isAccessible: false },
+  delete: { isVisible: false, isAccessible: false },
+  bulkDelete: { isVisible: false, isAccessible: false },
+};

--- a/backoffice/resources/community-benefit/community-benefit.resource.ts
+++ b/backoffice/resources/community-benefit/community-benefit.resource.ts
@@ -1,6 +1,9 @@
 import { CommunityBenefitSharingFund } from '@shared/entities/cost-inputs/community-benefit-sharing-fund.entity.js';
 import { ResourceWithOptions } from 'adminjs';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const CommunityBenefitResource: ResourceWithOptions = {
   resource: CommunityBenefitSharingFund,
@@ -18,6 +21,9 @@ export const CommunityBenefitResource: ResourceWithOptions = {
       communityBenefitSharingFund: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/community-cash-flow/community-cash-flow.resource.ts
+++ b/backoffice/resources/community-cash-flow/community-cash-flow.resource.ts
@@ -1,6 +1,9 @@
 import { CommunityCashFlow } from '@shared/entities/cost-inputs/community-cash-flow.entity.js';
 import { ResourceWithOptions } from 'adminjs';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const CommunityCashFlowResource: ResourceWithOptions = {
   resource: CommunityCashFlow,
@@ -15,6 +18,9 @@ export const CommunityCashFlowResource: ResourceWithOptions = {
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/community-representation/community-representation.resource.ts
+++ b/backoffice/resources/community-representation/community-representation.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { CommunityRepresentation } from '@shared/entities/cost-inputs/community-representation.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const CommunityRepresentationResource: ResourceWithOptions = {
   resource: CommunityRepresentation,
@@ -18,6 +21,9 @@ export const CommunityRepresentationResource: ResourceWithOptions = {
       liaisonCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/conservation-and-planning-admin/conservation-and-planning-admin.resource.ts
+++ b/backoffice/resources/conservation-and-planning-admin/conservation-and-planning-admin.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { ConservationPlanningAndAdmin } from '@shared/entities/cost-inputs/conservation-and-planning-admin.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const ConservationAndPlanningAdminResource: ResourceWithOptions = {
   resource: ConservationPlanningAndAdmin,
@@ -18,6 +21,9 @@ export const ConservationAndPlanningAdminResource: ResourceWithOptions = {
     navigation: {
       name: 'Model Components',
       icon: 'Settings',
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/countries/country.resource.ts
+++ b/backoffice/resources/countries/country.resource.ts
@@ -1,5 +1,8 @@
 import { ResourceWithOptions } from 'adminjs';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 import { Country } from '@shared/entities/country.entity.js';
 
 export const CountryResource: ResourceWithOptions = {
@@ -18,6 +21,9 @@ export const CountryResource: ResourceWithOptions = {
     navigation: {
       name: 'Model Components',
       icon: 'Settings',
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/data-collection-and-field-cost/data-collection-and-field-cost.resource.ts
+++ b/backoffice/resources/data-collection-and-field-cost/data-collection-and-field-cost.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { DataCollectionAndFieldCosts } from '@shared/entities/cost-inputs/data-collection-and-field-costs.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const DataCollectionAndFieldCostResource: ResourceWithOptions = {
   resource: DataCollectionAndFieldCosts,
@@ -18,6 +21,9 @@ export const DataCollectionAndFieldCostResource: ResourceWithOptions = {
       fieldCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts
+++ b/backoffice/resources/ecosystem-extent/ecosystem-extent.resource.ts
@@ -7,6 +7,7 @@ import {
   fetchRelatedSourcesActionHandler,
 } from 'backoffice/resources/common/many-2-many-sources.actions.js';
 import { EcosystemExtent } from '@shared/entities/carbon-inputs/ecosystem-extent.entity.js';
+import { DEFAULT_READONLY_PERMISSIONS } from 'backoffice/resources/common/common.resources.js';
 
 const FIELD_ORDER = [
   'countryCode',
@@ -58,6 +59,7 @@ export const EcosystemExtentResource: ResourceWithOptions = {
       },
     },
     actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
       fetchRelatedSourcesAction: {
         actionType: 'record',
         isVisible: false,

--- a/backoffice/resources/ecosystem-loss/ecosystem-loss.resource.ts
+++ b/backoffice/resources/ecosystem-loss/ecosystem-loss.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { EcosystemLoss } from '@shared/entities/carbon-inputs/ecosystem-loss.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const EcosystemLossResource: ResourceWithOptions = {
   resource: EcosystemLoss,
   options: {
@@ -17,6 +20,9 @@ export const EcosystemLossResource: ResourceWithOptions = {
       ecosystemLossRate: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/emission-factors/emission-factors.resource.ts
+++ b/backoffice/resources/emission-factors/emission-factors.resource.ts
@@ -5,7 +5,10 @@ import {
   ResourceWithOptions,
 } from 'adminjs';
 import { EmissionFactors } from '@shared/entities/carbon-inputs/emission-factors.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 import { Components } from 'backoffice/components/index.js';
 import {
   addSourceActionHandler,
@@ -62,6 +65,7 @@ export const EmissionFactorsResource: ResourceWithOptions = {
       },
     },
     actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
       fetchRelatedSourcesAction: {
         actionType: 'record',
         isVisible: false,

--- a/backoffice/resources/feasability-analysis/feasability-analysis.resource.ts
+++ b/backoffice/resources/feasability-analysis/feasability-analysis.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { FeasibilityAnalysis } from '@shared/entities/cost-inputs/feasability-analysis.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const FeasibilityAnalysisResource: ResourceWithOptions = {
   resource: FeasibilityAnalysis,
@@ -18,6 +21,9 @@ export const FeasibilityAnalysisResource: ResourceWithOptions = {
       analysisCost: {
         isVisible: { list: true, show: true, edit: true, filter: false },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/financing-cost/financing-cost.resource.ts
+++ b/backoffice/resources/financing-cost/financing-cost.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { FinancingCost } from '@shared/entities/cost-inputs/financing-cost.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const FinancingCostResource: ResourceWithOptions = {
   resource: FinancingCost,
   options: {
@@ -17,6 +20,9 @@ export const FinancingCostResource: ResourceWithOptions = {
       financingCostCapexPercent: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/implementation-labor-cost/implementation-labor-cost.resource.ts
+++ b/backoffice/resources/implementation-labor-cost/implementation-labor-cost.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { ImplementationLaborCost } from '@shared/entities/cost-inputs/implementation-labor-cost.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 import {
   fetchRelatedSourcesActionHandler,
   addSourceActionHandler,
@@ -53,6 +56,7 @@ export const ImplementationLaborCostResource: ResourceWithOptions = {
       },
     },
     actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
       fetchRelatedSourcesAction: {
         actionType: 'record',
         isVisible: false,

--- a/backoffice/resources/long-term-project-operating/long-term-project-operating.resource.ts
+++ b/backoffice/resources/long-term-project-operating/long-term-project-operating.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { LongTermProjectOperating } from '@shared/entities/cost-inputs/long-term-project-operating.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const LongTermProjectOperatingResource: ResourceWithOptions = {
   resource: LongTermProjectOperating,
   options: {
@@ -17,6 +20,9 @@ export const LongTermProjectOperatingResource: ResourceWithOptions = {
       longTermProjectOperatingCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/maintenance/maintenance.resource.ts
+++ b/backoffice/resources/maintenance/maintenance.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { Maintenance } from '@shared/entities/cost-inputs/maintenance.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 import {
   fetchRelatedSourcesActionHandler,
   addSourceActionHandler,
@@ -42,6 +45,7 @@ export const MaintenanceResource: ResourceWithOptions = {
       },
     },
     actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
       fetchRelatedSourcesAction: {
         actionType: 'record',
         isVisible: false,

--- a/backoffice/resources/model-assumptions/model-assumptions.resource.ts
+++ b/backoffice/resources/model-assumptions/model-assumptions.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { ModelAssumptions } from '@shared/entities/model-assumptions.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const ModelAssumptionResource: ResourceWithOptions = {
   resource: ModelAssumptions,
@@ -18,6 +21,9 @@ export const ModelAssumptionResource: ResourceWithOptions = {
       name: {
         isVisible: { list: true, show: true, filter: true, edit: false },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/model-component-source/model-component-source.resource.ts
+++ b/backoffice/resources/model-component-source/model-component-source.resource.ts
@@ -1,6 +1,9 @@
 import { ModelComponentSource } from '@shared/entities/methodology/model-component-source.entity.js';
 import { ResourceWithOptions } from 'adminjs';
-import { GLOBAL_COMMON_PROPERTIES } from 'backoffice/resources/common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from 'backoffice/resources/common/common.resources.js';
 
 export const ModelComponentSourceResource: ResourceWithOptions = {
   resource: ModelComponentSource,
@@ -15,6 +18,9 @@ export const ModelComponentSourceResource: ResourceWithOptions = {
     },
     properties: {
       ...GLOBAL_COMMON_PROPERTIES,
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/monitoring-cost/monitoring-cost.resource.ts
+++ b/backoffice/resources/monitoring-cost/monitoring-cost.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { MonitoringCost } from '@shared/entities/cost-inputs/monitoring.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 
 export const MonitoringCostResource: ResourceWithOptions = {
   resource: MonitoringCost,
@@ -18,6 +21,9 @@ export const MonitoringCostResource: ResourceWithOptions = {
       monitoringCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/mrv/mrv.resource.ts
+++ b/backoffice/resources/mrv/mrv.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { MRV } from '@shared/entities/cost-inputs/mrv.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const MRVResource: ResourceWithOptions = {
   resource: MRV,
   options: {
@@ -17,6 +20,9 @@ export const MRVResource: ResourceWithOptions = {
       mrvCost: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/project-size/project-size.resource.ts
+++ b/backoffice/resources/project-size/project-size.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { ProjectSize } from '@shared/entities/cost-inputs/project-size.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const ProjectSizeResource: ResourceWithOptions = {
   resource: ProjectSize,
   options: {
@@ -23,6 +26,9 @@ export const ProjectSizeResource: ResourceWithOptions = {
         isVisible: { list: true, show: true, edit: true, filter: false },
         description: 'Size in hectares',
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/projects/projects.resource.ts
+++ b/backoffice/resources/projects/projects.resource.ts
@@ -1,7 +1,6 @@
 import { ActionContext, ActionRequest, ResourceWithOptions } from 'adminjs';
 import { Project } from '@shared/entities/projects.entity.js';
 import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
-import { ProjectActions } from 'backoffice/resources/projects/project.actions.js';
 import { Components } from 'backoffice/components/index.js';
 
 const CREATE_EDIT_FORM_FIELDS = [
@@ -58,12 +57,15 @@ export const ProjectsResource: ResourceWithOptions = {
     },
     actions: {
       new: {
-        isAccessible: true,
+        isAccessible: false,
         component: Components.ProjectDynamicForm,
       },
       edit: {
-        isAccessible: true,
+        isAccessible: false,
         component: Components.ProjectDynamicForm,
+      },
+      delete: {
+        isAccessible: false,
       },
       bulkDelete: {
         isAccessible: false,

--- a/backoffice/resources/restorable-land/restorable-land.resource.ts
+++ b/backoffice/resources/restorable-land/restorable-land.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { RestorableLand } from '@shared/entities/carbon-inputs/restorable-land.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const RestorableLandResource: ResourceWithOptions = {
   resource: RestorableLand,
   options: {
@@ -17,6 +20,9 @@ export const RestorableLandResource: ResourceWithOptions = {
       restorableLand: {
         isVisible: { list: true, show: true, filter: false, edit: true },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };

--- a/backoffice/resources/sequestration-rate/sequestration-rate.resource.ts
+++ b/backoffice/resources/sequestration-rate/sequestration-rate.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { SequestrationRate } from '@shared/entities/carbon-inputs/sequestration-rate.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 import {
   fetchRelatedSourcesActionHandler,
   addSourceActionHandler,
@@ -52,6 +55,7 @@ export const SequestrationRateResource: ResourceWithOptions = {
       },
     },
     actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
       fetchRelatedSourcesAction: {
         actionType: 'record',
         isVisible: false,

--- a/backoffice/resources/validation-cost/validation-cost.resource.ts
+++ b/backoffice/resources/validation-cost/validation-cost.resource.ts
@@ -1,6 +1,9 @@
 import { ResourceWithOptions } from 'adminjs';
 import { ValidationCost } from '@shared/entities/cost-inputs/validation.entity.js';
-import { GLOBAL_COMMON_PROPERTIES } from '../common/common.resources.js';
+import {
+  DEFAULT_READONLY_PERMISSIONS,
+  GLOBAL_COMMON_PROPERTIES,
+} from '../common/common.resources.js';
 export const ValidationCostResource: ResourceWithOptions = {
   resource: ValidationCost,
   options: {
@@ -17,6 +20,9 @@ export const ValidationCostResource: ResourceWithOptions = {
       validationCost: {
         isVisible: { list: true, show: true, edit: true, filter: false },
       },
+    },
+    actions: {
+      ...DEFAULT_READONLY_PERMISSIONS,
     },
   },
 };


### PR DESCRIPTION
This pull request introduces a new constant, `DEFAULT_READONLY_PERMISSIONS`, to standardize readonly permissions across multiple resources in the backoffice module. It also applies these permissions to various resource files by updating their `actions` properties.

### Introduction of `DEFAULT_READONLY_PERMISSIONS`:
* [`backoffice/resources/common/common.resources.ts`](diffhunk://#diff-54dea6ce32eaf864518690b1f2cc09abd4453681742d4e14e939d58c0daa1803R24-R30): Added a new constant, `DEFAULT_READONLY_PERMISSIONS`, which disables visibility and accessibility for `new`, `edit`, `delete`, and `bulkDelete` actions.

### Application of `DEFAULT_READONLY_PERMISSIONS` to resources:
* Updated imports to include `DEFAULT_READONLY_PERMISSIONS` in the following resource files:
  - `backoffice/resources/base-increase/base-increase.resource.ts`
  - `backoffice/resources/base-size/base-size.resource.ts`
  - `backoffice/resources/baseline-reassesment/baseline-reassesment.resource.ts`
  - `backoffice/resources/blue-carbon-project-planning/blue-carbon-project-planning.resource.ts`
  - And others (similar changes in 15+ files).

* Updated the `actions` property in resource configurations to include `DEFAULT_READONLY_PERMISSIONS`:
  - `BaseIncreaseResource`
  - `BaseSizeResource`
  - `BaselineReassessmentResource`
  - `BlueCarbonProjectPlanningResource`
  - `CarbonStandardFeesResource`
  - And others (similar changes in 15+ files).