### PR TITLE
[TBCCT-441] resize map correctly after toggling filters

### DIFF
--- a/client/src/containers/overview/index.tsx
+++ b/client/src/containers/overview/index.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 import { useMap } from "react-map-gl";
 
 import { motion } from "framer-motion";
@@ -35,6 +37,16 @@ export default function Overview() {
 
     map.resize();
   };
+
+  useEffect(() => {
+    const resizeTimedOut = setTimeout(() => {
+      if (map) {
+        map.resize();
+      }
+    }, LAYOUT_TRANSITIONS.duration * 1000);
+
+    return () => clearTimeout(resizeTimedOut);
+  }, [filtersOpen, map]);
 
   return (
     <motion.div


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `Overview` component in `client/src/containers/overview/index.tsx`. It ensures that the map resizes properly when certain state changes occur, improving the user interface's responsiveness.

Enhancements to map resizing:

* [`client/src/containers/overview/index.tsx`](diffhunk://#diff-4132fd1974a92d212e088e860d1fa76acffc6f7929c857efa46ea1fe3a90b4d3R41-R50): Added a `useEffect` hook that triggers a delayed map resize whenever `filtersOpen` or `map` changes. This ensures the map adjusts dynamically after layout transitions.
* [`client/src/containers/overview/index.tsx`](diffhunk://#diff-4132fd1974a92d212e088e860d1fa76acffc6f7929c857efa46ea1fe3a90b4d3R3-R4): Imported `useEffect` from React to support the new functionality.