### PR TITLE
[TBCCT-438/444] polishes useScrollSpy behaviour

### DIFF
--- a/client/src/containers/profile/index.tsx
+++ b/client/src/containers/profile/index.tsx
@@ -81,7 +81,6 @@ export default function Profile() {
     setCurrentStep: setProfileStep,
     options: {
       threshold: 0.1,
-      rootMargin: "-20% 0% -60% 0%",
     },
   });
 

--- a/client/src/containers/projects/form/index.tsx
+++ b/client/src/containers/projects/form/index.tsx
@@ -45,6 +45,7 @@ export default function CustomProjectForm({ id }: CustomProjectFormProps) {
     setCurrentStep: setIntersecting,
     options: {
       threshold: 0.4,
+      rootMargin: "-30% 0% 0% 0%",
     },
     deps: [activity],
   });

--- a/client/src/hooks/use-scroll-spy.ts
+++ b/client/src/hooks/use-scroll-spy.ts
@@ -1,4 +1,4 @@
-import { useEffect, RefObject, DependencyList } from "react";
+import { DependencyList, RefObject, useEffect } from "react";
 
 interface UseScrollSpyProps<T> {
   /**
@@ -38,12 +38,19 @@ export function useScrollSpy<T>({
 
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const sectionSlug = entry.target.id as T;
-            setCurrentStep(sectionSlug);
+        const intersectedEntries = entries.filter(
+          (entry) => entry.isIntersecting,
+        );
+
+        if (intersectedEntries.length > 0) {
+          const firstIntersected = intersectedEntries[0];
+          const sectionId = firstIntersected.target.getAttribute("id");
+          if (sectionId) {
+            setCurrentStep(sectionId as T);
           }
-        });
+        } else {
+          setCurrentStep(null as unknown as T);
+        }
       },
       {
         root: containerRef.current,


### PR DESCRIPTION
This pull request includes updates to the `useScrollSpy` hook and its usage in components, along with a minor import reordering. The most important changes focus on improving the logic for handling intersecting elements in the `useScrollSpy` hook and updating the `rootMargin` configuration for specific components.

### Updates to `useScrollSpy` hook:

* Refactored the logic in the `IntersectionObserver` callback to filter and handle only intersecting entries, ensuring the first intersected element is processed. If no elements are intersecting, the `setCurrentStep` function is called with `null`. This improves clarity and robustness when managing scroll-based interactions. (`client/src/hooks/use-scroll-spy.ts`, [client/src/hooks/use-scroll-spy.tsL41-L46](diffhunk://#diff-f7d8e05dd9a3bfeaee09500fcc9862e37d9a215b1c11c849af58daa51c52ab8cL41-L46))

### Component-specific adjustments:

* Removed the `rootMargin` property from the `Profile` component's `useScrollSpy` configuration, simplifying its scroll behavior. (`client/src/containers/profile/index.tsx`, [client/src/containers/profile/index.tsxL84](diffhunk://#diff-bedfa722b2459f4c481bfab0c27069ee402e6da0c94f1e9468e1e784ebe05bfaL84))
* Added a `rootMargin` property to the `CustomProjectForm` component's `useScrollSpy` configuration, fine-tuning its scroll behavior for better user experience. (`client/src/containers/projects/form/index.tsx`, [client/src/containers/projects/form/index.tsxR48](diffhunk://#diff-b7b3abb8fa529d3b1a1538e1766448db4f276992b88b540d88b769ae79624726R48))

### Code style improvement:

* Reordered imports in `use-scroll-spy.ts` to follow a consistent and logical structure. (`client/src/hooks/use-scroll-spy.ts`, [client/src/hooks/use-scroll-spy.tsL1-R1](diffhunk://#diff-f7d8e05dd9a3bfeaee09500fcc9862e37d9a215b1c11c849af58daa51c52ab8cL1-R1))