### PR TITLE
[TBCCT-447] homogenizes errors and makes one-time password mismatch more obvious

### DIFF
--- a/client/src/containers/auth/set-password/form/action.ts
+++ b/client/src/containers/auth/set-password/form/action.ts
@@ -38,7 +38,9 @@ export async function signUpAction(
       return {
         ok: false,
         message:
-          response.body.errors?.map(({ title }) => title) ?? "unknown error",
+          response.body.errors?.map(({ title }) =>
+            title === "Unauthorized" ? "One time password incorrect" : title,
+          ) ?? "unknown error",
       };
     }
   } catch (error: Error | unknown) {

--- a/client/src/containers/auth/set-password/form/index.tsx
+++ b/client/src/containers/auth/set-password/form/index.tsx
@@ -20,13 +20,14 @@ import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
-  FormDescription,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast/use-toast";
 
 import { signUpAction } from "./action";
 import { signUpSchemaForm } from "./schema";
@@ -38,6 +39,8 @@ const SignUpForm: FC = () => {
     message: "",
   });
   const params = useParams<{ token: string }>();
+
+  const { toast } = useToast();
 
   const formRef = useRef<HTMLFormElement>(null);
   const form = useForm<z.infer<typeof signUpSchemaForm>>({
@@ -78,126 +81,136 @@ const SignUpForm: FC = () => {
 
   const isDisabledByTokenValidation = !isValidToken || isFetching || isError;
 
+  useEffect(() => {
+    if (!isValidToken && !isFetching) {
+      setTimeout(() => {
+        toast({
+          variant: "destructive",
+          description: "The token is invalid or has expired.",
+        });
+      }, 0);
+    }
+  }, [isValidToken, isFetching, toast]);
+
+  useEffect(() => {
+    if (!status.ok) {
+      toast({
+        variant: "destructive",
+        description: status.message,
+      });
+    }
+  }, [status, toast]);
+
   return (
-    <>
-      {!isValidToken && !isFetching && (
-        <p className="text-center text-sm text-destructive">
-          The token is invalid or has expired.
-        </p>
-      )}
-      {status.ok === false && (
-        <p className="text-center text-sm text-destructive">{status.message}</p>
-      )}
-      <Form {...form}>
-        <form
-          ref={formRef}
-          action={formAction}
-          className="w-full space-y-4"
-          onSubmit={(evt) => {
-            evt.preventDefault();
-            form.handleSubmit(() => {
-              formAction(new FormData(formRef.current!));
-            })(evt);
-          }}
-        >
-          <FormField
-            control={form.control}
-            name="oneTimePassword"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>One-Time Password</FormLabel>
-                <FormControl>
+    <Form {...form}>
+      <form
+        ref={formRef}
+        action={formAction}
+        className="w-full space-y-4"
+        onSubmit={(evt) => {
+          evt.preventDefault();
+          form.handleSubmit(() => {
+            formAction(new FormData(formRef.current!));
+          })(evt);
+        }}
+      >
+        <FormField
+          control={form.control}
+          name="oneTimePassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>One-Time Password</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Enter the One-Time Password received in your mail"
+                  required
+                  disabled={isDisabledByTokenValidation}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="newPassword"
+          render={({ field, fieldState }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <div className="relative flex items-center">
                   <Input
-                    placeholder="Enter the One-Time Password received in your mail"
-                    required
+                    placeholder="Create a password"
+                    type="password"
+                    autoComplete="new-password"
                     disabled={isDisabledByTokenValidation}
                     {...field}
                   />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="newPassword"
-            render={({ field, fieldState }) => (
-              <FormItem>
-                <FormLabel>Password</FormLabel>
-                <FormControl>
-                  <div className="relative flex items-center">
-                    <Input
-                      placeholder="Create a password"
-                      type="password"
-                      autoComplete="new-password"
-                      disabled={isDisabledByTokenValidation}
-                      {...field}
-                    />
-                  </div>
-                </FormControl>
-                {!fieldState.invalid && (
-                  <FormDescription>
-                    Password must contain at least 8 characters.
-                  </FormDescription>
-                )}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="repeatPassword"
-            render={({ field, fieldState }) => (
-              <FormItem>
-                <FormLabel>Repeat password</FormLabel>
-                <FormControl>
-                  <div className="relative flex items-center">
-                    <Input
-                      placeholder="Repeat the password"
-                      type="password"
-                      autoComplete="new-password"
-                      disabled={isDisabledByTokenValidation}
-                      {...field}
-                    />
-                  </div>
-                </FormControl>
-                {!fieldState.invalid && (
-                  <FormDescription>
-                    Password must contain at least 8 characters.
-                  </FormDescription>
-                )}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+                </div>
+              </FormControl>
+              {!fieldState.invalid && (
+                <FormDescription>
+                  Password must contain at least 8 characters.
+                </FormDescription>
+              )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="repeatPassword"
+          render={({ field, fieldState }) => (
+            <FormItem>
+              <FormLabel>Repeat password</FormLabel>
+              <FormControl>
+                <div className="relative flex items-center">
+                  <Input
+                    placeholder="Repeat the password"
+                    type="password"
+                    autoComplete="new-password"
+                    disabled={isDisabledByTokenValidation}
+                    {...field}
+                  />
+                </div>
+              </FormControl>
+              {!fieldState.invalid && (
+                <FormDescription>
+                  Password must contain at least 8 characters.
+                </FormDescription>
+              )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-          <FormField
-            control={form.control}
-            name="token"
-            render={({ field }) => (
-              <FormItem>
-                <FormControl>
-                  <Input type="hidden" {...field} />
-                </FormControl>
-              </FormItem>
-            )}
-          />
+        <FormField
+          control={form.control}
+          name="token"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input type="hidden" {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
 
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" asChild>
-              <Link href="/auth/signin">Cancel</Link>
-            </Button>
-            <Button
-              variant="secondary"
-              type="submit"
-              disabled={!form.formState.isValid || isDisabledByTokenValidation}
-            >
-              Save
-            </Button>
-          </div>
-        </form>
-      </Form>
-    </>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" asChild>
+            <Link href="/auth/signin">Cancel</Link>
+          </Button>
+          <Button
+            variant="secondary"
+            type="submit"
+            disabled={!form.formState.isValid || isDisabledByTokenValidation}
+          >
+            Save
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 };
 

--- a/e2e/tests/auth/sign-up.spec.ts
+++ b/e2e/tests/auth/sign-up.spec.ts
@@ -101,7 +101,7 @@ test.describe("Auth - Sign Up", () => {
     await page.goto(ROUTES.auth.signup + "/12345678");
 
     await expect(
-      page.getByText("The token is invalid or has expired."),
+      page.getByText('The token is invalid or has expired.', { exact: true }),
     ).toBeVisible();
     await expect(
       page.getByPlaceholder(


### PR DESCRIPTION
This pull request enhances error handling and user feedback in the sign-up form by introducing toast notifications for errors and improving error message clarity. Additionally, it removes redundant error messages from the UI. Below are the key changes grouped by theme:

### Improved Error Messaging:
* Updated the `signUpAction` function to replace the generic "Unauthorized" error message with a more user-friendly "One time password incorrect" message. (`client/src/containers/auth/set-password/form/action.ts`)

### Enhanced User Feedback:
* Introduced toast notifications to display error messages for invalid tokens and unsuccessful sign-up attempts. This replaces inline error messages with more dynamic feedback using the `useToast` hook. (`client/src/containers/auth/set-password/form/index.tsx`)
* Removed redundant inline error messages for invalid tokens and sign-up status, simplifying the UI. (`client/src/containers/auth/set-password/form/index.tsx`) [[1]](diffhunk://#diff-9b219668c6bd20a5ac3c0ff30b9c7016c248cace4e8beeefb80009fa9d106808R84-L90) [[2]](diffhunk://#diff-9b219668c6bd20a5ac3c0ff30b9c7016c248cace4e8beeefb80009fa9d106808L200)

### Code Refactoring:
* Adjusted imports to include `useToast` and reorganized the `FormDescription` import for better readability. (`client/src/containers/auth/set-password/form/index.tsx`)