### PR TITLE
[TBCCT-473] methodology: versions

### DIFF
--- a/client/src/app/methodology/page.tsx
+++ b/client/src/app/methodology/page.tsx
@@ -22,6 +22,11 @@ export default async function MethodologyPage() {
     queryFn: () => client.methodology.getAllModelAssumptions.query(),
   });
 
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.methodology.changelogs.queryKey,
+    queryFn: () => client.methodology.getChangeLogs.query(),
+  });
+
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Methodology />

--- a/client/src/containers/methodology/sections/index.tsx
+++ b/client/src/containers/methodology/sections/index.tsx
@@ -6,6 +6,8 @@ import ProjectCostsAssumptionsAndMethodology from "@/containers/methodology/sect
 import ProjectSizeAssumptions from "@/containers/methodology/sections/project-size-assumptions";
 import QualitativeScorecardDetailsAndSources from "@/containers/methodology/sections/qualitative-scorecard-details-and-sources";
 import Sources from "@/containers/methodology/sections/sources";
+import Versions from "@/containers/methodology/sections/versions";
+
 export interface MethodologySection {
   id: string;
   title: string;
@@ -22,6 +24,7 @@ const METHODOLOGY_SECTIONS: MethodologySection[] = [
   QualitativeScorecardDetailsAndSources,
   LimitationsOfTheTool,
   Sources,
+  Versions,
 ];
 
 export default METHODOLOGY_SECTIONS;

--- a/client/src/containers/methodology/sections/versions/index.tsx
+++ b/client/src/containers/methodology/sections/versions/index.tsx
@@ -1,0 +1,27 @@
+import { MethodologySection } from "@/containers/methodology/sections";
+import VersionsTable from "@/containers/methodology/sections/versions/table";
+import ContentWrapper from "@/containers/methodology/wrapper";
+
+const Versions: MethodologySection = {
+  id: "versions",
+  title: "Versions",
+  href: "#versions",
+  Content: (
+    <div className="space-y-4">
+      <ContentWrapper>
+        <p>
+          This section compiles and documents the different changes made to the
+          calculation methodology over time. Each version includes a name and a
+          date of update, and reflects adjustments or improvements introduced to
+          the process. Projects that have already been calculated are not
+          automatically updated to the latest version of the methodology. If you
+          wish to update a project to a newer version, please review the changes
+          made in each field to understand how they might affect the results.
+        </p>
+      </ContentWrapper>
+      <VersionsTable />
+    </div>
+  ),
+};
+
+export default Versions;

--- a/client/src/containers/methodology/sections/versions/table.tsx
+++ b/client/src/containers/methodology/sections/versions/table.tsx
@@ -1,0 +1,70 @@
+import { Changelog } from "@shared/entities/model-versioning/changelog.type";
+import { AlertTriangleIcon } from "lucide-react";
+
+import { client } from "@/lib/query-client";
+import { queryKeys } from "@/lib/query-keys";
+
+import MethodologyTable, {
+  MethodologyBaseTableRow,
+  MethodologyTableDefinition,
+} from "@/containers/methodology/table";
+import { versionsHeaders } from "@/containers/methodology/table/data";
+
+const getTableData = (changelogs: Changelog[]) => {
+  const rows: MethodologyTableDefinition<MethodologyBaseTableRow>["rows"] = [];
+
+  changelogs.forEach((changelog) => {
+    rows.push({
+      id: changelog.versionName,
+      ...changelog,
+      createdAt: new Date(changelog.createdAt).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }),
+      versionNotes: (
+        <div
+          dangerouslySetInnerHTML={{
+            __html: changelog.versionNotes ? changelog.versionNotes : "N/A",
+          }}
+        />
+      ),
+    });
+  });
+
+  return { headers: versionsHeaders, rows };
+};
+
+const queryKey = queryKeys.methodology.changelogs.queryKey;
+const VersionsTable = () => {
+  const { data } = client.methodology.getChangeLogs.useQuery(
+    queryKey,
+    {},
+    {
+      queryKey,
+      select: (data) => {
+        const sortedChangelogs = data.body.data.sort(
+          (a, b) =>
+            new Date(b?.createdAt as unknown as string).getTime() -
+            new Date(a?.createdAt as unknown as string).getTime(),
+        );
+        return getTableData(sortedChangelogs as Changelog[]);
+      },
+    },
+  );
+
+  if (!data?.rows.length) {
+    return (
+      <div className="!mt-12 px-2">
+        <div className="flex justify-center gap-2">
+          <AlertTriangleIcon className="h-5 w-5" />
+          <p className="text-center">No versions published yet</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <MethodologyTable data={data} />;
+};
+
+export default VersionsTable;

--- a/client/src/containers/methodology/table/data.tsx
+++ b/client/src/containers/methodology/table/data.tsx
@@ -784,6 +784,12 @@ export const sourcesHeaders = {
   sources: "Sources",
 };
 
+export const versionsHeaders = {
+  versionName: "Version Name",
+  createdAt: "Date of update",
+  versionNotes: "Notes",
+};
+
 export const modelAssumptionsHeaders = {
   assumptions: "Assumptions",
   units: "Units",

--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -110,6 +110,7 @@ export const customProjectKeys = createQueryKeys("customProjects", {
 const methodologyKeys = createQueryKeys("methodology", {
   sources: null,
   modelAssumptions: null,
+  changelogs: null,
 });
 
 export const queryKeys = mergeQueryKeys(


### PR DESCRIPTION
This pull request introduces a new "Versions" section to the methodology page, which documents changes to the calculation methodology over time. It includes updates to prefetch changelog data, integrates the new section into the methodology structure, and implements a table to display version details.

### Additions to the Methodology Page:
* Added prefetching of changelog data in `MethodologyPage` to optimize loading for the new "Versions" section (`client/src/app/methodology/page.tsx`).

### Integration of the "Versions" Section:
* Imported and registered the `Versions` component in the `METHODOLOGY_SECTIONS` array to include it in the methodology page structure (`client/src/containers/methodology/sections/index.tsx`). [[1]](diffhunk://#diff-07da5e8a18a746af616939178b73dad92782986c64a8e38ec752976cf3fa8186R9-R10) [[2]](diffhunk://#diff-07da5e8a18a746af616939178b73dad92782986c64a8e38ec752976cf3fa8186R27)
* Created a new `Versions` component, which includes a description and a table for displaying version details (`client/src/containers/methodology/sections/versions/index.tsx`).

### Implementation of the Versions Table:
* Developed the `VersionsTable` component to fetch, sort, and display changelog data in a tabular format (`client/src/containers/methodology/sections/versions/table.tsx`).
* Added `versionsHeaders` to define the column headers for the versions table (`client/src/containers/methodology/table/data.tsx`).

### Supporting Changes:
* Added a new `changelogs` key to `queryKeys.methodology` to support querying changelog data (`client/src/lib/query-keys.ts`).