### PR TITLE
[TBCCT-474] enables the Salt Marsh ecosystem to be recognized as a valid ecosystem with a T2 emission factor

### DIFF
--- a/api/test/integration/custom-projects/custom-projects-validations.spec.ts
+++ b/api/test/integration/custom-projects/custom-projects-validations.spec.ts
@@ -160,7 +160,7 @@ describe('Create Custom Projects - Request Validations', () => {
         'Project Specific Loss Rate must be between -100% and 0%',
       );
     });
-    test('If Emission Factor Used is Tier 2, only Mangroves is accepted as ecosystem', async () => {
+    test('If Emission Factor Used is Tier 2, only Mangroves and Salt Marsh are accepted as ecosystem', async () => {
       const res = await testManager
         .request()
         .post(customProjectContract.createCustomProject.path)
@@ -207,7 +207,7 @@ describe('Create Custom Projects - Request Validations', () => {
         });
 
       expect(res.body.errors[0].title).toEqual(
-        'There is only Tier 2 emission factor for Mangrove ecosystems',
+        'There is only Tier 2 emission factor for Mangrove and Salt Marsh ecosystems',
       );
     });
     test('If Emission Factor Used is Tier 3 and Project Specific Emission is Two Emission Factors, AGB and SOC should be provided', async () => {

--- a/api/test/integration/projects/create-projects-validations.spec.ts
+++ b/api/test/integration/projects/create-projects-validations.spec.ts
@@ -122,7 +122,7 @@ describe('Create projects Validations', () => {
       );
     });
 
-    test('should fail if Tier 2 is used and ecosystem is not MANGROVE', async () => {
+    test('should fail if Tier 2 is used and ecosystem is neither MANGROVE nor SALT MARSH', async () => {
       const body: CreateProjectDto = {
         countryCode: 'USA',
         projectName: 'Wrong Tier 2 Ecosystem',
@@ -147,7 +147,7 @@ describe('Create projects Validations', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.errors[0].title).toEqual(
-        'There is only Tier 2 emission factor for Mangrove ecosystems',
+        'There is only Tier 2 emission factor for Mangrove and Salt Marsh ecosystems',
       );
     });
 

--- a/client/src/containers/projects/form/setup/conservation-project-details/index.tsx
+++ b/client/src/containers/projects/form/setup/conservation-project-details/index.tsx
@@ -42,7 +42,7 @@ export default function ConservationProjectDetails() {
         value: factor,
         disabled:
           factor === PROJECT_EMISSION_FACTORS.TIER_2 &&
-          form.getValues("ecosystem") !== ECOSYSTEM.MANGROVE,
+          form.getValues("ecosystem") === ECOSYSTEM.SEAGRASS,
       };
     },
   );
@@ -150,12 +150,6 @@ export default function ConservationProjectDetails() {
                       v as EMISSION_FACTORS_TIER_TYPES,
                     );
                     await form.trigger("parameters.emissionFactorUsed");
-
-                    // ? selecting T2, the ecosystem must be set to mangrove
-                    if (v === EMISSION_FACTORS_TIER_TYPES.TIER_2) {
-                      form.setValue("ecosystem", ECOSYSTEM.MANGROVE);
-                      await form.trigger("ecosystem");
-                    }
                   }}
                 >
                   <SelectTrigger data-testid="parameters.emissionFactorUsed">

--- a/shared/schemas/custom-projects/create-custom-project.schema.ts
+++ b/shared/schemas/custom-projects/create-custom-project.schema.ts
@@ -284,10 +284,10 @@ export const ValidateConservationSchema = (
   }
 
   if (params.emissionFactorUsed === EMISSION_FACTORS_TIER_TYPES.TIER_2) {
-    if (data.ecosystem !== ECOSYSTEM.MANGROVE) {
+    if (data.ecosystem === ECOSYSTEM.SEAGRASS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "There is only Tier 2 emission factor for Mangrove ecosystems",
+        message: "There is only Tier 2 emission factor for Mangrove and Salt Marsh ecosystems",
         path: ["parameters.emissionFactorUsed"],
       });
     }

--- a/shared/schemas/projects/create-project.schema.ts
+++ b/shared/schemas/projects/create-project.schema.ts
@@ -1,13 +1,7 @@
-import {
-  ACTIVITY,
-  RESTORATION_ACTIVITY_SUBTYPE,
-} from "@shared/entities/activity.enum";
+import { ACTIVITY, RESTORATION_ACTIVITY_SUBTYPE } from "@shared/entities/activity.enum";
 import { ECOSYSTEM } from "@shared/entities/ecosystem.enum";
 import { z } from "zod";
-import {
-  CARBON_REVENUES_TO_COVER,
-  PROJECT_SPECIFIC_EMISSION,
-} from "@shared/entities/custom-project.entity";
+import { CARBON_REVENUES_TO_COVER, PROJECT_SPECIFIC_EMISSION } from "@shared/entities/custom-project.entity";
 import { EMISSION_FACTORS_TIER_TYPES } from "@shared/entities/carbon-inputs/emission-factors.entity";
 import { SEQUESTRATION_RATE_TIER_TYPES } from "@shared/entities/carbon-inputs/sequestration-rate.entity";
 import { LOSS_RATE_USED } from "@shared/schemas/custom-projects/create-custom-project.schema";
@@ -139,10 +133,10 @@ export const ValidateConservationSchema = (
   }
 
   if (params.emissionFactorUsed === EMISSION_FACTORS_TIER_TYPES.TIER_2) {
-    if (data.ecosystem !== ECOSYSTEM.MANGROVE) {
+    if (data.ecosystem === ECOSYSTEM.SEAGRASS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "There is only Tier 2 emission factor for Mangrove ecosystems",
+        message: "There is only Tier 2 emission factor for Mangrove and Salt Marsh ecosystems",
         path: ["parameters.emissionFactorUsed"],
       });
     }


### PR DESCRIPTION
This pull request updates the validation logic for Tier 2 emission factors in conservation and custom project creation. The main change is to allow both Mangrove and Salt Marsh ecosystems for Tier 2 emission factors, whereas previously only Mangrove was permitted. Related test cases, error messages, and frontend logic have been updated to reflect this expanded eligibility.

**BLOCKED:** https://vizzuality.atlassian.net/browse/TBCCT-480?focusedCommentId=38007

**Validation logic updates:**

* In both `shared/schemas/projects/create-project.schema.ts` and `shared/schemas/custom-projects/create-custom-project.schema.ts`, the validation now restricts Tier 2 emission factors only when the ecosystem is Seagrass, allowing Mangrove and Salt Marsh. Error messages have been updated accordingly. [[1]](diffhunk://#diff-8cb02bcf20baf608d0d7b7c1b72d0c9a5b0dca284d2abb3c6a6a763dd8737b6dL142-R139) [[2]](diffhunk://#diff-e2acc2e0e44826a98602752f24e3062f9cfd0526a60190ad2f8b02d0127fdbf0L287-R290)

**Test updates:**

* Test descriptions and expected error messages in `api/test/integration/projects/create-projects-validations.spec.ts` and `api/test/integration/custom-projects/custom-projects-validations.spec.ts` have been changed to reflect the new logic, now checking that Tier 2 is invalid only for Seagrass, and updating error messages to include Salt Marsh. [[1]](diffhunk://#diff-84de67793ee211891b215fed417791c757e35f9df7da5a8d97688486cd6394acL125-R125) [[2]](diffhunk://#diff-84de67793ee211891b215fed417791c757e35f9df7da5a8d97688486cd6394acL150-R150) [[3]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012L163-R163) [[4]](diffhunk://#diff-040b506e0f69f9191a8bcb6e0753ccce4b01ab36f3ca0c7ca06e699087f23012L210-R210)

**Frontend logic updates:**

* In `client/src/containers/projects/form/setup/conservation-project-details/index.tsx`, the disabling logic for emission factor selection now disables Tier 2 only when the ecosystem is Seagrass, not for other ecosystems. Also, the auto-setting of the ecosystem to Mangrove when Tier 2 is selected has been removed. [[1]](diffhunk://#diff-bb75aea2efea8ce9fbc2513d24e8e17e6baec4e0f03636d050504192a643697dL45-R45) [[2]](diffhunk://#diff-bb75aea2efea8ce9fbc2513d24e8e17e6baec4e0f03636d050504192a643697dL153-L158)

**Code style:**

* Minor import formatting improvements in `shared/schemas/projects/create-project.schema.ts` for readability.