### PR TITLE
[TBCCT-482] fixes methodology section highlighting

### DIFF
--- a/client/src/containers/methodology/index.tsx
+++ b/client/src/containers/methodology/index.tsx
@@ -23,8 +23,7 @@ export default function Methodology() {
     containerRef: ref,
     setCurrentStep: setMethodologyStep,
     options: {
-      threshold: 0.05,
-      rootMargin: "0% 0% -35% 0%",
+      threshold: 0.2,
     },
   });
 

--- a/client/src/hooks/use-scroll-spy.ts
+++ b/client/src/hooks/use-scroll-spy.ts
@@ -48,8 +48,6 @@ export function useScrollSpy<T>({
           if (sectionId) {
             setCurrentStep(sectionId as T);
           }
-        } else {
-          setCurrentStep(null as unknown as T);
         }
       },
       {


### PR DESCRIPTION
This pull request introduces improvements to the scroll spy behavior in the methodology section of the client application. The main changes involve adjusting the scroll detection sensitivity and refining how the current step is set when scrolling.

Scroll spy behavior adjustments:

* Increased the `threshold` value from 0.05 to 0.3 in the scroll spy options within `client/src/containers/methodology/index.tsx`, making the step change trigger less sensitive to small scrolls.
* Removed the logic that set the current step to `null` when no section was detected in `client/src/hooks/use-scroll-spy.ts`, ensuring the current step remains unchanged unless a new section is detected.