### PR TITLE
[TBCCT-483] makes annual project cash flow chart scrollable in small screens

### DIFF
--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -53,7 +53,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex flex-1 justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className,
         )}
         {...props}

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx
@@ -82,7 +82,7 @@ const CashflowChart: FC<CashflowChartProps> = ({
           icon: () => <div className="h-[3px] w-[24px] bg-destructive" />,
         },
       }}
-      className="cashflow-chart min-h-[200px] w-full"
+      className="cashflow-chart h-full w-full"
     >
       <ComposedChart data={data} stackOffset="sign" accessibilityLayer>
         <CartesianGrid

--- a/client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx
+++ b/client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx
@@ -11,6 +11,7 @@ import CashFlowTable from "@/containers/projects/custom-project/annual-project-c
 import { YearlyBreakdownChartData } from "@/containers/projects/custom-project/annual-project-cash-flow/utils";
 
 import { Card } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface AnnualProjectCashFlowProps {
   chartData: YearlyBreakdownChartData;
@@ -26,16 +27,21 @@ const AnnualProjectCashFlow: FC<AnnualProjectCashFlowProps> = ({
 }) => {
   const [tab] = useProjectCashFlowTab();
   return (
-    <Card variant="secondary" className="flex flex-col overflow-hidden p-0">
+    <Card
+      variant="secondary"
+      className="flex flex-1 flex-col overflow-hidden p-0"
+    >
       <Header />
       {tab === "table" ? (
         <CashFlowTable data={tableData} />
       ) : (
-        <CashflowChart
-          data={chartData}
-          carbonRevenuesToCover={carbonRevenuesToCover}
-          breakevenPoint={breakevenPoint}
-        />
+        <ScrollArea className="flex-1">
+          <CashflowChart
+            data={chartData}
+            carbonRevenuesToCover={carbonRevenuesToCover}
+            breakevenPoint={breakevenPoint}
+          />
+        </ScrollArea>
       )}
     </Card>
   );


### PR DESCRIPTION
This pull request makes improvements to the layout and responsiveness of the annual project cash flow components, ensuring that charts and containers properly fill available space and are scrollable when needed. The changes primarily update flex and sizing classes, and add a scroll area for better usability.

**Layout and Responsiveness Improvements**

* Changed the `ChartContainer` component to use `flex-1` instead of `aspect-video`, allowing charts to grow and fill available space more effectively. (`client/src/components/ui/chart.tsx`)
* Updated the `CashflowChart` container to use `h-full` for height, ensuring it occupies the full available vertical space. (`client/src/containers/projects/custom-project/annual-project-cash-flow/chart/index.tsx`)
* Modified the `AnnualProjectCashFlow` card container to use `flex-1`, making the card and its contents expand to fill the parent container. (`client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx`)

**Usability Enhancements**

* Wrapped the chart view in a `ScrollArea` to enable scrolling when chart content exceeds the visible area, improving accessibility and user experience. (`client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx`)
* Imported the `ScrollArea` component to support scrollable chart content. (`client/src/containers/projects/custom-project/annual-project-cash-flow/index.tsx`)