### PR TITLE
Front end tweaks

### DIFF
--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -97,7 +97,7 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
   ),
   columnHelper.accessor("abatementPotential", {
     enableSorting: true,
-    header: renderHeader("Abatement potential (tCO2e/yr)"),
+    header: renderHeader("Credit potential (tCO2e/yr)"),
     cell: (props) => {
       const value = props.getValue();
       if (value === null || value === undefined) {

--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -103,6 +103,14 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
       if (value === null || value === undefined) {
         return "-";
       }
+      if ((value as unknown as string) === "0") {
+        return (
+          <CellText className="whitespace-nowrap">
+            Minimal or insignificant loss rates
+          </CellText>
+        );
+      }
+
       const state = props.table.getState() as TableStateWithMaximums;
 
       return (


### PR DESCRIPTION
This pull request updates the `abatementPotential` column in the overview table to improve clarity for users. The header label has been changed, and a special message is now displayed for cases where the value is zero.

**Table column improvements:**

* Changed the column header from "Abatement potential (tCO2e/yr)" to "Credit potential (tCO2e/yr)" for better alignment with terminology.
* Added logic to display "Minimal or insignificant loss rates" instead of "0" when the value is zero, making the table output more user-friendly and descriptive.