### PR TITLE
Front end tweaks

### DIFF
--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -97,7 +97,7 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
   ),
   columnHelper.accessor("abatementPotential", {
     enableSorting: true,
-    header: renderHeader("Abatement potential (tCO2e/yr)"),
+    header: renderHeader("Credit potential (tCO2e/yr)"),
     cell: (props) => {
       const value = props.getValue();
       if (value === null || value === undefined) {

--- a/client/src/containers/overview/table/view/overview/columns.tsx
+++ b/client/src/containers/overview/table/view/overview/columns.tsx
@@ -103,6 +103,14 @@ export const columns = (filters: z.infer<typeof filtersSchema>) => [
       if (value === null || value === undefined) {
         return "-";
       }
+      if ((value as unknown as string) === "0") {
+        return (
+          <CellText className="whitespace-nowrap">
+            Minimal or insignificant loss rates
+          </CellText>
+        );
+      }
+
       const state = props.table.getState() as TableStateWithMaximums;
 
       return (

--- a/client/src/containers/projects/custom-project/details/detail-item/index.tsx
+++ b/client/src/containers/projects/custom-project/details/detail-item/index.tsx
@@ -58,7 +58,7 @@ const DetailItem: FC<DetailItemProps> = ({
             compactUnit
           />
         ) : value !== undefined && value !== null ? (
-          <span className="text-xl">{formatValue(value)}</span>
+          <span className="2xl:text-xl">{formatValue(value)}</span>
         ) : null}
       </div>
       {subValues?.map((subValue, index) => (

--- a/client/src/containers/projects/custom-project/index.tsx
+++ b/client/src/containers/projects/custom-project/index.tsx
@@ -121,7 +121,12 @@ const CustomProjectView: FC<{
         <div className="mb-4 mt-2 flex gap-4">
           <ProjectDetails {...projectDetailsProps} />
           {projectCostProps && <ProjectCost {...projectCostProps} />}
-          {leftOverProps && <LeftOver {...leftOverProps} />}
+          {leftOverProps && (
+            <LeftOver
+              carbonRevenuesToCover={data.input.carbonRevenuesToCover}
+              {...leftOverProps}
+            />
+          )}
           {costDetailsProps && (
             <CostDetails
               data={costDetailsProps}

--- a/client/src/containers/projects/custom-project/left-over/index.tsx
+++ b/client/src/containers/projects/custom-project/left-over/index.tsx
@@ -3,8 +3,10 @@ import { FC } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { GraphWithLegend } from "@/components/ui/graph";
 import { Label } from "@/components/ui/label";
+import { CARBON_REVENUES_TO_COVER } from "@shared/entities/custom-project.entity";
 
 interface LeftoverProps {
+  carbonRevenuesToCover: CARBON_REVENUES_TO_COVER;
   title: string;
   tooltip: {
     title: string;
@@ -17,7 +19,12 @@ interface LeftoverProps {
   };
 }
 
-const LeftOver: FC<LeftoverProps> = ({ data, title, tooltip }) => {
+const LeftOver: FC<LeftoverProps> = ({
+  data,
+  title,
+  tooltip,
+  carbonRevenuesToCover,
+}) => {
   return (
     <Card variant="secondary" className="grid flex-1 gap-1 p-0">
       <CardHeader className="p-4 pb-0">
@@ -46,7 +53,10 @@ const LeftOver: FC<LeftoverProps> = ({ data, title, tooltip }) => {
             items={[
               {
                 value: data.opex,
-                label: "OpEx",
+                label:
+                  carbonRevenuesToCover === CARBON_REVENUES_TO_COVER.OPEX
+                    ? "OpEx"
+                    : "Total",
                 circleClassName: "bg-sky-blue-200",
                 labelClassName: "text-sky-blue-200",
               },


### PR DESCRIPTION
This pull request introduces several UI and logic improvements to the custom project overview and details pages, focusing on clearer terminology, enhanced data display, and improved component flexibility. The most significant updates include renaming a column for clarity, enhancing the `LeftOver` component to handle new props and logic, and refining value display in project details.

**Terminology and Data Display Updates:**

* The "Abatement potential (tCO2e/yr)" column header in the overview table was renamed to "Credit potential (tCO2e/yr)" for improved clarity. Additionally, if the value is zero, the cell now displays "Minimal or insignificant loss rates" instead of "0".

* In the project details, the value display now uses a responsive text size class (`2xl:text-xl`) for better visual consistency across screen sizes.

**Component Logic and Prop Enhancements:**

* The `LeftOver` component now receives a new prop, `carbonRevenuesToCover`, and uses it to dynamically determine whether to label a graph segment as "OpEx" or "Total" based on its value. [[1]](diffhunk://#diff-9767320b8339ac7e849e6f7513c68cb1d947566005de22466a4fa0fbdb7afc11R6-R10) [[2]](diffhunk://#diff-9767320b8339ac7e849e6f7513c68cb1d947566005de22466a4fa0fbdb7afc11L20-R28) [[3]](diffhunk://#diff-9767320b8339ac7e849e6f7513c68cb1d947566005de22466a4fa0fbdb7afc11L49-R60)

* The parent component (`CustomProjectView`) was updated to pass the new `carbonRevenuesToCover` prop to `LeftOver`, ensuring the component has the necessary data for its new logic.