### PR TITLE
N/a google analytics user consent

### DIFF
--- a/client/src/app/(overview)/store.ts
+++ b/client/src/app/(overview)/store.ts
@@ -2,6 +2,7 @@ import { MapMouseEvent } from "react-map-gl";
 
 import { COST_TYPE_SELECTOR } from "@shared/entities/projects.entity";
 import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 import { z } from "zod";
 
 import { filtersSchema } from "@/app/(overview)/constants";
@@ -37,3 +38,12 @@ const INITIAL_FILTERS_STATE: ProjectDetailsFilters = {
 };
 
 export const projectDetailsFiltersAtom = atom(INITIAL_FILTERS_STATE);
+
+/**
+ * Store whether the user has given consent to the use of analytics. If `undefined`, the user has
+ * not given consent nor rejected the use yet. If `true`, the user consents to the use of analytics.
+ */
+export const analyticsConsentAtom = atomWithStorage<boolean | undefined>(
+  "analytics-consent",
+  undefined,
+);

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren } from "react";
 
 import { Spline_Sans } from "next/font/google";
 
-import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import "@/app/globals.css";
 import { getServerSession } from "next-auth";
@@ -13,8 +12,10 @@ import { config } from "@/app/auth/api/[...nextauth]/config";
 import IntroModal from "@/containers/intro-modal";
 import MainNav from "@/containers/nav";
 
+import PrivacyBanner from "@/components/privacy-banner";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import Toaster from "@/components/ui/toast/toaster";
+import GoogleAnalytics from "@/scripts/google-analytics";
 
 import LayoutProviders from "./providers";
 
@@ -63,9 +64,10 @@ export default async function RootLayout({
               <main className="flex h-dvh flex-1">{children}</main>
             </SidebarProvider>
             <Toaster />
+            <PrivacyBanner />
           </body>
         </NuqsAdapter>
-        <GoogleAnalytics gaId="G-N6HX0XYEGG" />
+        <GoogleAnalytics />
       </html>
     </LayoutProviders>
   );

--- a/client/src/components/privacy-banner/index.tsx
+++ b/client/src/components/privacy-banner/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAtom } from "jotai";
+
+import { analyticsConsentAtom } from "@/app/(overview)/store";
+
+import { Button } from "@/components/ui/button";
+
+export default function PrivacyBanner() {
+  const [mounted, setMounted] = useState(false);
+  const [consent, setConsent] = useAtom(analyticsConsentAtom);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (consent !== undefined || !mounted) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 z-50 grid w-full grid-cols-12 items-center justify-between border-t bg-background px-12 py-6 xl:px-[100px]">
+      <p className="col-span-8 text-sm xl:col-span-6">
+        We use cookies to enhance site navigation, analyze site usage, customize
+        your experience, and assist in our marketing efforts. By clicking
+        &quot;Accept All Cookies&quot; you agree to the storing of performance,
+        functional, and targeting cookies on your device. If you do not agree to
+        the storing of any cookies that are not strictly necessary for the
+        functioning of the site on your device, click on &quot;Deny all non
+        essential cookies&quot;. For more information, review our Privacy
+        Statement.{" "}
+        <a
+          href="https://www.nature.org/en-us/about-us/who-we-are/accountability/privacy-policy/"
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium underline"
+        >
+          View our Privacy Statement.
+        </a>
+      </p>
+      <div className="col-span-4 flex flex-col-reverse items-center justify-end gap-6 xl:col-span-6 xl:flex-row">
+        <Button onClick={() => setConsent(false)} variant="outline">
+          Deny all non essential cookies
+        </Button>
+        <Button onClick={() => setConsent(true)}>Accept all cookies</Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/scripts/google-analytics.tsx
+++ b/client/src/scripts/google-analytics.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { GoogleAnalytics as GA } from "@next/third-parties/google";
+import { useAtom } from "jotai";
+
+import { analyticsConsentAtom } from "@/app/(overview)/store";
+
+const GA_ID = "G-N6HX0XYEGG";
+
+export default function GoogleAnalytics() {
+  const [mounted, setMounted] = useState(false);
+  const [consent] = useAtom(analyticsConsentAtom);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || consent === false) {
+    return null;
+  }
+
+  return <GA gaId={GA_ID} />;
+}

--- a/e2e/tests/auth/sign-up.spec.ts
+++ b/e2e/tests/auth/sign-up.spec.ts
@@ -27,10 +27,11 @@ test.describe("Auth - Sign Up", () => {
     await testManager.close();
   });
 
-  test("an user signs up successfully", async ({ page }) => {
+  test("an user signs up successfully", async () => {
     const user = TEST_USER;
 
     await page.goto(ROUTES.auth.signup);
+    await testManager.acceptAnalytics();
 
     await page.getByPlaceholder("Enter your name").fill(user.name);
     await page
@@ -62,9 +63,7 @@ test.describe("Auth - Sign Up", () => {
     expect(registeredUser?.isActive).toBe(false);
   });
 
-  test("an user successfully finish signup process with OTP", async ({
-    page,
-  }) => {
+  test("an user successfully finish signup process with OTP", async () => {
     const user = {
       ...TEST_USER,
       isActive: false,

--- a/e2e/tests/auth/update-password.spec.ts
+++ b/e2e/tests/auth/update-password.spec.ts
@@ -19,10 +19,6 @@ test.describe("Auth - Update Password", () => {
     await testManager.clearDatabase();
   });
 
-  test.afterEach(async () => {
-    // await testManager.clearDatabase();
-  });
-
   test.afterAll(async () => {
     await testManager.close();
   });
@@ -36,6 +32,9 @@ test.describe("Auth - Update Password", () => {
 
     await page.waitForURL(ROUTES.home);
     await page.goto(ROUTES.profile);
+
+    await testManager.acceptAnalytics();
+    
     await page
       .getByPlaceholder("Type your current password")
       .fill(user.password);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5522,10 +5522,6 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  detect-libc@2.0.3:
-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
-    engines: {node: '>=8'}
-
   detect-libc@2.1.0:
     resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
     engines: {node: '>=8'}
@@ -9566,13 +9562,13 @@ snapshots:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.775.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.775.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
@@ -9601,13 +9597,13 @@ snapshots:
 
   '@aws-crypto/supports-web-crypto@5.2.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-crypto/util@5.2.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.782.0':
     dependencies:
@@ -9801,7 +9797,7 @@ snapshots:
       '@smithy/util-middleware': 3.0.6
       '@smithy/util-retry': 3.0.6
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -9844,7 +9840,7 @@ snapshots:
       '@smithy/util-middleware': 4.0.2
       '@smithy/util-retry': 4.0.2
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -9925,7 +9921,7 @@ snapshots:
       '@aws-sdk/types': 3.649.0
       '@smithy/property-provider': 3.1.6
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.775.0':
     dependencies:
@@ -9933,7 +9929,7 @@ snapshots:
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.649.0':
     dependencies:
@@ -9945,7 +9941,7 @@ snapshots:
       '@smithy/smithy-client': 3.3.2
       '@smithy/types': 3.4.2
       '@smithy/util-stream': 3.1.6
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.775.0':
     dependencies:
@@ -9958,7 +9954,7 @@ snapshots:
       '@smithy/smithy-client': 4.2.0
       '@smithy/types': 4.2.0
       '@smithy/util-stream': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.651.1(@aws-sdk/client-sso-oidc@3.651.1(@aws-sdk/client-sts@3.651.1))(@aws-sdk/client-sts@3.651.1)':
     dependencies:
@@ -9973,7 +9969,7 @@ snapshots:
       '@smithy/property-provider': 3.1.6
       '@smithy/shared-ini-file-loader': 3.1.7
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
@@ -9992,7 +9988,7 @@ snapshots:
       '@smithy/property-provider': 4.0.2
       '@smithy/shared-ini-file-loader': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -10038,7 +10034,7 @@ snapshots:
       '@smithy/property-provider': 3.1.6
       '@smithy/shared-ini-file-loader': 3.1.7
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.775.0':
     dependencies:
@@ -10047,7 +10043,7 @@ snapshots:
       '@smithy/property-provider': 4.0.2
       '@smithy/shared-ini-file-loader': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.651.1(@aws-sdk/client-sso-oidc@3.651.1(@aws-sdk/client-sts@3.651.1))':
     dependencies:
@@ -10057,7 +10053,7 @@ snapshots:
       '@smithy/property-provider': 3.1.6
       '@smithy/shared-ini-file-loader': 3.1.7
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
@@ -10071,7 +10067,7 @@ snapshots:
       '@smithy/property-provider': 4.0.2
       '@smithy/shared-ini-file-loader': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -10081,7 +10077,7 @@ snapshots:
       '@aws-sdk/types': 3.649.0
       '@smithy/property-provider': 3.1.6
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.782.0':
     dependencies:
@@ -10090,7 +10086,7 @@ snapshots:
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -10253,7 +10249,7 @@ snapshots:
       '@smithy/util-middleware': 4.0.2
       '@smithy/util-retry': 4.0.2
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -10291,7 +10287,7 @@ snapshots:
       '@smithy/property-provider': 3.1.6
       '@smithy/shared-ini-file-loader': 3.1.7
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.782.0':
     dependencies:
@@ -10300,7 +10296,7 @@ snapshots:
       '@smithy/property-provider': 4.0.2
       '@smithy/shared-ini-file-loader': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -10316,7 +10312,7 @@ snapshots:
 
   '@aws-sdk/util-arn-parser@3.723.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.649.0':
     dependencies:
@@ -10334,7 +10330,7 @@ snapshots:
 
   '@aws-sdk/util-locate-window@3.568.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.649.0':
     dependencies:
@@ -11390,7 +11386,7 @@ snapshots:
 
   '@emnapi/runtime@1.5.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
     optional: true
 
   '@emotion/babel-plugin@11.12.0':
@@ -12018,14 +12014,14 @@ snapshots:
 
   '@mapbox/node-pre-gyp@1.0.11':
     dependencies:
-      detect-libc: 2.0.3
+      detect-libc: 2.1.0
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
       node-fetch: 2.7.0
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.7.2
       tar: 6.2.1
     transitivePeerDependencies:
       - encoding
@@ -12960,21 +12956,21 @@ snapshots:
   '@smithy/abort-controller@3.1.4':
     dependencies:
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/abort-controller@4.0.2':
     dependencies:
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.0.0':
     dependencies:
       '@smithy/util-base64': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/chunked-blob-reader@5.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/config-resolver@3.0.8':
     dependencies:
@@ -13022,7 +13018,7 @@ snapshots:
       '@smithy/property-provider': 3.1.6
       '@smithy/types': 3.4.2
       '@smithy/url-parser': 3.0.6
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.0.2':
     dependencies:
@@ -13030,14 +13026,14 @@ snapshots:
       '@smithy/property-provider': 4.0.2
       '@smithy/types': 4.2.0
       '@smithy/url-parser': 4.0.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.0.2':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.2.0
       '@smithy/util-hex-encoding': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.0.2':
     dependencies:
@@ -13060,7 +13056,7 @@ snapshots:
     dependencies:
       '@smithy/eventstream-codec': 4.0.2
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/fetch-http-handler@3.2.7':
     dependencies:
@@ -13117,15 +13113,15 @@ snapshots:
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/is-array-buffer@3.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/is-array-buffer@4.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/md5-js@4.0.2':
     dependencies:
@@ -13243,12 +13239,12 @@ snapshots:
   '@smithy/property-provider@3.1.6':
     dependencies:
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/property-provider@4.0.2':
     dependencies:
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/protocol-http@4.1.3':
     dependencies:
@@ -13264,23 +13260,23 @@ snapshots:
     dependencies:
       '@smithy/types': 3.4.2
       '@smithy/util-uri-escape': 3.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/querystring-builder@4.0.2':
     dependencies:
       '@smithy/types': 4.2.0
       '@smithy/util-uri-escape': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/querystring-parser@3.0.6':
     dependencies:
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/querystring-parser@4.0.2':
     dependencies:
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/service-error-classification@3.0.6':
     dependencies:
@@ -13293,12 +13289,12 @@ snapshots:
   '@smithy/shared-ini-file-loader@3.1.7':
     dependencies:
       '@smithy/types': 3.4.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.0.2':
     dependencies:
       '@smithy/types': 4.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/signature-v4@4.1.3':
     dependencies:
@@ -13309,7 +13305,7 @@ snapshots:
       '@smithy/util-middleware': 3.0.6
       '@smithy/util-uri-escape': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/signature-v4@5.0.2':
     dependencies:
@@ -13320,7 +13316,7 @@ snapshots:
       '@smithy/util-middleware': 4.0.2
       '@smithy/util-uri-escape': 4.0.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/smithy-client@3.3.2':
     dependencies:
@@ -13392,25 +13388,25 @@ snapshots:
   '@smithy/util-buffer-from@2.2.0':
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-buffer-from@3.0.0':
     dependencies:
       '@smithy/is-array-buffer': 3.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-buffer-from@4.0.0':
     dependencies:
       '@smithy/is-array-buffer': 4.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-config-provider@3.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-config-provider@4.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@3.0.18':
     dependencies:
@@ -13462,11 +13458,11 @@ snapshots:
 
   '@smithy/util-hex-encoding@3.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-middleware@3.0.6':
     dependencies:
@@ -13499,7 +13495,7 @@ snapshots:
       '@smithy/util-buffer-from': 3.0.0
       '@smithy/util-hex-encoding': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-stream@4.2.0':
     dependencies:
@@ -13514,16 +13510,16 @@ snapshots:
 
   '@smithy/util-uri-escape@3.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-uri-escape@4.0.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@smithy/util-utf8@3.0.0':
     dependencies:
@@ -14193,7 +14189,7 @@ snapshots:
 
   '@types/pg@8.11.10':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.15.21
       pg-protocol: 1.6.1
       pg-types: 4.0.2
 
@@ -15624,10 +15620,7 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@2.0.3: {}
-
-  detect-libc@2.1.0:
-    optional: true
+  detect-libc@2.1.0: {}
 
   detect-newline@3.1.0: {}
 
@@ -15892,7 +15885,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -15927,7 +15920,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -15945,7 +15938,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -16956,7 +16949,7 @@ snapshots:
       '@babel/parser': 7.25.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.3
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17585,7 +17578,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.2
 
   make-error@1.3.6: {}
 
@@ -18564,7 +18557,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.5)(react@18.3.1)
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.5
 
@@ -18630,7 +18623,7 @@ snapshots:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.3.1
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.5
 
@@ -18900,8 +18893,7 @@ snapshots:
 
   semver@7.6.3: {}
 
-  semver@7.7.2:
-    optional: true
+  semver@7.7.2: {}
 
   send@0.18.0:
     dependencies:
@@ -19655,7 +19647,7 @@ snapshots:
       reflect-metadata: 0.2.2
       sha.js: 2.4.11
       sql-highlight: 6.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       uuid: 11.1.0
       yargs: 17.7.2
     optionalDependencies:
@@ -19677,7 +19669,7 @@ snapshots:
       reflect-metadata: 0.2.2
       sha.js: 2.4.11
       sql-highlight: 6.0.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       uuid: 11.1.0
       yargs: 17.7.2
     optionalDependencies:
@@ -19762,7 +19754,7 @@ snapshots:
   use-callback-ref@1.3.2(@types/react@18.3.5)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.5
 
@@ -19780,7 +19772,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.5
 

--- a/shared/lib/e2e-test-manager.ts
+++ b/shared/lib/e2e-test-manager.ts
@@ -1,10 +1,7 @@
 import { DataSource } from "typeorm";
 import { User } from "@shared/entities/users/user.entity";
 import { createProject, createUser } from "@shared/lib/entity-mocks";
-import {
-  clearTablesByEntities,
-  clearTestDataFromDatabase,
-} from "@shared/lib/db-helpers";
+import { clearTablesByEntities, clearTestDataFromDatabase } from "@shared/lib/db-helpers";
 import { JwtPayload, sign } from "jsonwebtoken";
 import { TOKEN_TYPE_ENUM } from "@shared/schemas/auth/token-type.schema";
 import { COMMON_DATABASE_ENTITIES } from "@shared/lib/db-entities";
@@ -100,6 +97,10 @@ export class E2eTestManager {
   async logout() {
     await this.page.goto("/auth/api/signout");
     await this.page.getByRole("button", { name: "Sign out" }).click();
+  }
+  
+  async acceptAnalytics() {
+    await this.page.getByRole("button", { name: /Accept all cookies/i }).click();
   }
 
   async generateTokenByType(user: User, tokenType: TOKEN_TYPE_ENUM) {


### PR DESCRIPTION
This pull request introduces a privacy banner to collect user consent for analytics cookies and updates the Google Analytics integration to respect this consent. It also refactors how analytics are loaded, ensures e2e tests handle the new consent flow, and updates several package dependencies for improved stability.

**User privacy and analytics consent:**

* Added a new `PrivacyBanner` component (`client/src/components/privacy-banner/index.tsx`) that prompts users to accept or deny non-essential cookies, storing their choice in `analyticsConsentAtom` using persistent storage. [[1]](diffhunk://#diff-ae37e73eb1ed82f2809b02f5ac22db2230aab3bb5ead446634a6483a297a0e65R1-R51) [[2]](diffhunk://#diff-f92e0805e51ab61002069a3c2fb94c19901d89f75c3b572d921a867a06938f33R41-R49)
* Updated the Google Analytics integration to only load if the user has given consent, moving logic to a new client-side component (`client/src/scripts/google-analytics.tsx`) and removing unconditional loading from `layout.tsx`. [[1]](diffhunk://#diff-f57eac4a99395dfe0f7774b4bdfa80fe8450a95a8f7daedde892098422735a2eR1-R25) [[2]](diffhunk://#diff-534df09572a415c8de5c39cdc4a3f923f9e4ea042e2536ffa5e18b01118bdaecR15-R18) [[3]](diffhunk://#diff-534df09572a415c8de5c39cdc4a3f923f9e4ea042e2536ffa5e18b01118bdaecR67-R70) [[4]](diffhunk://#diff-534df09572a415c8de5c39cdc4a3f923f9e4ea042e2536ffa5e18b01118bdaecL5)

**State management:**

* Introduced `atomWithStorage` from `jotai/utils` to persist analytics consent state in local storage. [[1]](diffhunk://#diff-f92e0805e51ab61002069a3c2fb94c19901d89f75c3b572d921a867a06938f33R5) [[2]](diffhunk://#diff-f92e0805e51ab61002069a3c2fb94c19901d89f75c3b572d921a867a06938f33R41-R49)

**Testing updates:**

* Updated e2e tests to handle the analytics consent banner by programmatically accepting analytics before proceeding with form interactions. [[1]](diffhunk://#diff-cae5171467796e3f647c0e88167e1aef2b1b08393eed21cbb94cd23e12c49443R34) [[2]](diffhunk://#diff-b8262cb8b0cdee870a91507ec8d6ad0aea166119d3052b38c4449f4df4bf6ec6R35-R36)

**Dependency updates:**

* Changed version specifiers for `@next/third-parties` to allow minor upgrades and updated several dependencies in `pnpm-lock.yaml` (notably `tslib`, `detect-libc`, and `semver`) for improved compatibility and security. [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL17-R17) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL346-R346) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5525-L5528) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9569-R9571) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12021-R12024)